### PR TITLE
Implement local pipeline, CLI, and web API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+      - name: Run tests
+        run: |
+          pytest --maxfail=1 --disable-warnings --cov

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/Oracle_one_move
+++ b/Oracle_one_move
@@ -1,24 +1,125 @@
-from dataclasses import replace
+"""Compatibility CLI for single-move analysis using the local pipeline."""
 
-from oracle.config import Settings, load_settings, resolve_value
-from oracle.interfaces.cli.single_move import run_single_move_cli
+from __future__ import annotations
 
-OPENAI_API_KEY = ""
-STOCKFISH_PATH = ""
-MODEL_NAME = "gpt-3.5-turbo-instruct"
-DEPTH = 5
-PROB_THRESHOLD = 0.001
+import io
+import os
+from typing import Callable, Dict, Optional
+
+import chess
+import chess.pgn
+
+from oracle.pipeline.analyze import analyze as default_analyze
+
+DEFAULT_ELO = 1500
+DEFAULT_TIME_CONTROL = "classical"
 
 
-def _apply_overrides(settings: Settings) -> Settings:
-    return replace(
-        settings,
-        openai_api_key=resolve_value(OPENAI_API_KEY, settings.openai_api_key),
-        stockfish_path=resolve_value(STOCKFISH_PATH, settings.stockfish_path),
-        model_name=resolve_value(MODEL_NAME, settings.model_name),
+def _read_pgn_from_input() -> str:
+    print('Enter the PGN (finish with an empty line or EOF):')
+    lines = []
+    try:
+        while True:
+            line = input()
+            if not line.strip():
+                break
+            lines.append(line)
+    except EOFError:
+        pass
+    return "\n".join(lines).strip()
+
+
+def _derive_context(pgn: str) -> Dict[str, object]:
+    elo_env = os.getenv("ORACLE_ELO")
+    time_env = os.getenv("ORACLE_TIME_CONTROL")
+
+    game = chess.pgn.read_game(io.StringIO(pgn))
+    headers = game.headers if game else {}
+
+    def _parse_elo(value: Optional[str]) -> int:
+        if not value:
+            return DEFAULT_ELO
+        try:
+            return int(value)
+        except (ValueError, TypeError):
+            return DEFAULT_ELO
+
+    elo = _parse_elo(headers.get("WhiteElo") or headers.get("BlackElo") or elo_env)
+    time_control = _normalize_time_control(
+        headers.get("TimeControl") or time_env or DEFAULT_TIME_CONTROL
     )
+
+    return {"elo": elo, "time_control": time_control}
+
+
+def _normalize_time_control(value: str) -> str:
+    value = value.lower()
+    if value in {"bullet", "blitz", "rapid", "classical"}:
+        return value
+    base = value.split("+")[0]
+    try:
+        if ":" in base:
+            minutes, seconds = base.split(":")
+            total_seconds = int(minutes) * 60 + int(seconds)
+        else:
+            total_seconds = int(base)
+    except ValueError:
+        return DEFAULT_TIME_CONTROL
+    if total_seconds <= 120:
+        return "bullet"
+    if total_seconds <= 300:
+        return "blitz"
+    if total_seconds <= 900:
+        return "rapid"
+    return "classical"
+
+
+def _format_sf_eval(move: Dict[str, object]) -> str:
+    if "sf_eval_mate" in move and move["sf_eval_mate"] is not None:
+        return f"M{move['sf_eval_mate']}"
+    if "sf_eval_cp" in move and move["sf_eval_cp"] is not None:
+        return f"{move['sf_eval_cp']}"
+    return ""
+
+
+def main(
+    pgn: Optional[str] = None,
+    *,
+    analyze_fn: Callable[..., Dict[str, object]] = default_analyze,
+    depth: int = 3,
+    prob_threshold: float = 0.0,
+    top_k: Optional[int] = None,
+) -> Dict[str, object]:
+    """Run the single-move CLI and return the analysis result."""
+
+    pgn_content = (pgn or _read_pgn_from_input()).strip()
+    if not pgn_content:
+        raise ValueError("No PGN provided")
+
+    context = _derive_context(pgn_content)
+
+    result = analyze_fn(
+        pgn=pgn_content,
+        ctx=context,
+        depth=depth,
+        prob_threshold=prob_threshold,
+        top_k=top_k,
+    )
+
+    print(f"Model: {result.get('model', 'unknown')}")
+    print(f"Expected score: {result.get('expected_score', 0.0):.3f}")
+    print("Move           Prior %   Adjusted %   SF Eval   Quality")
+    for move in result.get("moves", []):
+        print(
+            f"{move['san']:<12}"
+            f"{move.get('prior_pct', 0.0):>8.2f}"
+            f"{move.get('adjusted_pct', 0.0):>12.2f}"
+            f"{_format_sf_eval(move):>10}"
+            f"{move.get('quality', ''):>10}"
+        )
+
+    return result
 
 
 if __name__ == "__main__":
-    settings = _apply_overrides(load_settings())
-    run_single_move_cli(settings, depth=DEPTH, prob_threshold=PROB_THRESHOLD)
+    main()

--- a/Oracle_pgn_file
+++ b/Oracle_pgn_file
@@ -1,52 +1,146 @@
+"""Compatibility CLI for batch PGN analysis using the local pipeline."""
+
+from __future__ import annotations
+
 import argparse
-from dataclasses import replace
+import csv
+import io
+import os
+from typing import Callable, Dict, Iterable, Optional
 
-from oracle.config import Settings, load_settings, resolve_value
-from oracle.interfaces.cli.batch import run_batch_cli
+import chess
+import chess.pgn
 
-OPENAI_API_KEY = ""
-STOCKFISH_PATH = ""
-MODEL_NAME = "gpt-3.5-turbo-instruct"
-PGN_FILE_PATH = ".pgn"
-OUTPUT_FILE_PATH = "analysis_results.csv"
-DEPTH = 5
-PROB_THRESHOLD = 0.001
-DEFAULT_RATING = 2000
-DEFAULT_GAME_TYPE = "classical"
+from oracle.pipeline.analyze import analyze as default_analyze
 
-
-def _apply_overrides(settings: Settings) -> Settings:
-    return replace(
-        settings,
-        openai_api_key=resolve_value(OPENAI_API_KEY, settings.openai_api_key),
-        stockfish_path=resolve_value(STOCKFISH_PATH, settings.stockfish_path),
-        model_name=resolve_value(MODEL_NAME, settings.model_name),
-    )
+DEFAULT_ELO = 1500
+DEFAULT_TIME_CONTROL = "classical"
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Batch PGN analysis with Oracle")
-    parser.add_argument("--pgn", default=PGN_FILE_PATH, help="Path to the input PGN file")
-    parser.add_argument("--output", default=OUTPUT_FILE_PATH, help="Path to the output CSV file")
-    parser.add_argument("--depth", type=int, default=DEPTH, help="Depth for GPT exploration")
-    parser.add_argument("--prob-threshold", type=float, default=PROB_THRESHOLD, help="Probability threshold for token expansion")
-    parser.add_argument("--default-rating", type=int, default=DEFAULT_RATING, help="Fallback rating when PGN lacks Elo headers")
-    parser.add_argument("--game-type", default=DEFAULT_GAME_TYPE, help="Fallback game type when PGN lacks time control")
+    parser = argparse.ArgumentParser(description="Batch analyze PGN games")
+    parser.add_argument("--pgn", required=False, help="Path to PGN file")
+    parser.add_argument("--output", required=False, help="Path to CSV output")
+    parser.add_argument("--depth", type=int, default=3)
+    parser.add_argument("--prob-threshold", type=float, default=0.0)
+    parser.add_argument("--top-k", type=int, default=None)
     return parser.parse_args()
 
 
-def main() -> None:
-    args = _parse_args()
-    settings = _apply_overrides(load_settings())
-    run_batch_cli(
-        settings,
-        pgn_path=args.pgn,
-        output_path=args.output,
-        depth=args.depth,
-        prob_threshold=args.prob_threshold,
-        default_rating=args.default_rating,
-        default_game_type=args.game_type,
+def _iterate_games(path: str) -> Iterable[str]:
+    with open(path, "r", encoding="utf-8") as handle:
+        while True:
+            game = chess.pgn.read_game(handle)
+            if game is None:
+                break
+            exporter = chess.pgn.StringExporter(headers=True, variations=False, comments=False)
+            game.accept(exporter)
+            yield str(exporter)
+
+
+def _normalize_time_control(value: str) -> str:
+    value = value.lower()
+    if value in {"bullet", "blitz", "rapid", "classical"}:
+        return value
+    base = value.split("+")[0]
+    try:
+        if ":" in base:
+            minutes, seconds = base.split(":")
+            total_seconds = int(minutes) * 60 + int(seconds)
+        else:
+            total_seconds = int(base)
+    except ValueError:
+        return DEFAULT_TIME_CONTROL
+    if total_seconds <= 120:
+        return "bullet"
+    if total_seconds <= 300:
+        return "blitz"
+    if total_seconds <= 900:
+        return "rapid"
+    return "classical"
+
+
+def _derive_context(pgn: str) -> Dict[str, object]:
+    game = chess.pgn.read_game(io.StringIO(pgn))
+    headers = game.headers if game else {}
+
+    def _parse_elo(value: Optional[str]) -> int:
+        if not value:
+            return DEFAULT_ELO
+        try:
+            return int(value)
+        except (ValueError, TypeError):
+            return DEFAULT_ELO
+
+    elo_env = os.getenv("ORACLE_ELO")
+    time_env = os.getenv("ORACLE_TIME_CONTROL")
+
+    elo = _parse_elo(headers.get("WhiteElo") or headers.get("BlackElo") or elo_env)
+    time_control = _normalize_time_control(
+        headers.get("TimeControl") or time_env or DEFAULT_TIME_CONTROL
     )
+    return {"elo": elo, "time_control": time_control}
+
+
+def main(
+    *,
+    pgn_path: Optional[str] = None,
+    output_path: Optional[str] = None,
+    analyze_fn: Callable[..., Dict[str, object]] = default_analyze,
+    depth: int = 3,
+    prob_threshold: float = 0.0,
+    top_k: Optional[int] = None,
+) -> None:
+    if pgn_path is None or output_path is None:
+        args = _parse_args()
+        pgn_path = pgn_path or args.pgn
+        output_path = output_path or args.output
+        depth = args.depth
+        prob_threshold = args.prob_threshold
+        top_k = args.top_k
+
+    if not pgn_path or not output_path:
+        raise ValueError("Both PGN and output paths must be provided")
+
+    rows = []
+    for game_index, game_pgn in enumerate(_iterate_games(pgn_path), start=1):
+        context = _derive_context(game_pgn)
+        result = analyze_fn(
+            pgn=game_pgn,
+            ctx=context,
+            depth=depth,
+            prob_threshold=prob_threshold,
+            top_k=top_k,
+        )
+        for move_index, move in enumerate(result.get("moves", []), start=1):
+            rows.append(
+                {
+                    "game_index": game_index,
+                    "move_index": move_index,
+                    "san": move.get("san", ""),
+                    "prior_pct": move.get("prior_pct", 0.0),
+                    "adjusted_pct": move.get("adjusted_pct", 0.0),
+                    "sf_eval_cp": move.get("sf_eval_cp", ""),
+                    "quality": move.get("quality", ""),
+                }
+            )
+
+    with open(output_path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "game_index",
+                "move_index",
+                "san",
+                "prior_pct",
+                "adjusted_pct",
+                "sf_eval_cp",
+                "quality",
+            ],
+        )
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
 
 
 if __name__ == "__main__":

--- a/Oracle_web.py
+++ b/Oracle_web.py
@@ -1,41 +1,122 @@
-import logging
+"""Flask application exposing the analysis pipeline via JSON API."""
+
+from __future__ import annotations
+
 import os
-from dataclasses import replace
+from typing import Callable, Dict, Optional
 
-from oracle.config import Settings, load_settings, resolve_value
-from oracle.interfaces.web.app import create_app
+from flask import Flask, jsonify, request
+from flask_cors import CORS
 
-OPENAI_API_KEY = ""
-STOCKFISH_PATH = ""
-MODEL_NAME = "gpt-3.5-turbo-instruct"
-HOST = os.getenv("ORACLE_WEB_HOST", "127.0.0.1")
-PORT = int(os.getenv("ORACLE_WEB_PORT", "8000"))
-DEBUG = os.getenv("ORACLE_WEB_DEBUG", "false").lower() == "true"
-LOG_LEVEL = os.getenv("ORACLE_WEB_LOG_LEVEL", "DEBUG").upper()
-LOG_FORMAT = os.getenv(
-    "ORACLE_WEB_LOG_FORMAT",
-    "%(asctime)s [%(levelname)s] %(name)s - %(message)s",
-)
+from oracle.pipeline.analyze import analyze as default_analyze
+
+DEFAULT_ELO = 1500
+DEFAULT_TIME_CONTROL = "classical"
 
 
-def _apply_overrides(settings: Settings) -> Settings:
-    return replace(
-        settings,
-        openai_api_key=resolve_value(OPENAI_API_KEY, settings.openai_api_key),
-        stockfish_path=resolve_value(STOCKFISH_PATH, settings.stockfish_path),
-        model_name=resolve_value(MODEL_NAME, settings.model_name),
-    )
+def _normalize_time_control(value: str) -> str:
+    value = (value or DEFAULT_TIME_CONTROL).lower()
+    if value in {"bullet", "blitz", "rapid", "classical"}:
+        return value
+    return DEFAULT_TIME_CONTROL
+
+
+def _parse_context(payload: Dict[str, object]) -> Dict[str, object]:
+    context = payload.get("context") or {}
+    elo_value = context.get("elo")
+    try:
+        elo = int(elo_value) if elo_value is not None else DEFAULT_ELO
+    except (TypeError, ValueError):
+        elo = DEFAULT_ELO
+    time_control = _normalize_time_control(context.get("time_control", DEFAULT_TIME_CONTROL))
+    return {"elo": elo, "time_control": time_control}
+
+
+def create_app(analyze_fn: Callable[..., Dict[str, object]] = default_analyze) -> Flask:
+    app = Flask(__name__)
+    CORS(app, resources={r"/api/*": {"origins": "http://localhost:5173"}})
+
+    @app.post("/api/analyze")
+    def api_analyze():
+        payload = request.get_json(force=True) or {}
+        pgn = payload.get("pgn", "").strip()
+        if not pgn:
+            return jsonify({"error": "Missing PGN"}), 400
+        ctx = _parse_context(payload)
+        result = analyze_fn(pgn=pgn, ctx=ctx)
+        return jsonify(result)
+
+    @app.get("/")
+    def index():
+        return (
+            """<!doctype html>
+<html lang='en'>
+<head>
+  <meta charset='utf-8'>
+  <title>Oracle Analyzer</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    textarea { width: 100%; height: 200px; }
+    table { border-collapse: collapse; margin-top: 1rem; width: 100%; }
+    th, td { border: 1px solid #ccc; padding: 0.5rem; text-align: left; }
+  </style>
+</head>
+<body>
+  <h1>Oracle Analyzer</h1>
+  <label for='pgn'>PGN</label><br>
+  <textarea id='pgn'></textarea>
+  <div>
+    <label for='elo'>Elo:</label>
+    <input id='elo' type='number' value='1500'>
+    <label for='time_control'>Time Control:</label>
+    <select id='time_control'>
+      <option value='bullet'>bullet</option>
+      <option value='blitz'>blitz</option>
+      <option value='rapid' selected>rapid</option>
+      <option value='classical'>classical</option>
+    </select>
+    <button onclick='analyze()'>Analyze</button>
+  </div>
+  <div id='result'></div>
+<script>
+async function analyze() {
+  const payload = {
+    pgn: document.getElementById('pgn').value,
+    context: {
+      elo: parseInt(document.getElementById('elo').value, 10),
+      time_control: document.getElementById('time_control').value
+    }
+  };
+  const response = await fetch('/api/analyze', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  const container = document.getElementById('result');
+  if (!response.ok) {
+    container.innerHTML = '<p>Request failed</p>';
+    return;
+  }
+  const data = await response.json();
+  let html = `<p>Expected score: ${data.expected_score.toFixed(3)}</p>`;
+  html += '<table><thead><tr><th>Move</th><th>Prior %</th><th>Adjusted %</th><th>SF Eval</th><th>Quality</th></tr></thead><tbody>';
+  for (const move of data.moves) {
+    html += `<tr><td>${move.san}</td><td>${move.prior_pct.toFixed(2)}</td><td>${move.adjusted_pct.toFixed(2)}</td><td>${move.sf_eval_cp ?? ''}</td><td>${move.quality ?? ''}</td></tr>`;
+  }
+  html += '</tbody></table>';
+  container.innerHTML = html;
+}
+</script>
+</body>
+</html>
+"""
+        )
+
+    return app
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=LOG_LEVEL, format=LOG_FORMAT)
-    logging.getLogger(__name__).debug(
-        "Starting Oracle web server host=%s port=%s debug=%s log_level=%s",
-        HOST,
-        PORT,
-        DEBUG,
-        LOG_LEVEL,
-    )
-    settings = _apply_overrides(load_settings())
-    app = create_app(settings)
-    app.run(host=HOST, port=PORT, debug=DEBUG)
+    host = os.getenv("ORACLE_WEB_HOST", "127.0.0.1")
+    port = int(os.getenv("ORACLE_WEB_PORT", "8000"))
+    debug = os.getenv("ORACLE_WEB_DEBUG", "false").lower() == "true"
+    create_app().run(host=host, port=port, debug=debug)

--- a/oracle/calib/__init__.py
+++ b/oracle/calib/__init__.py
@@ -1,0 +1,5 @@
+"""Calibration utilities for Oracle."""
+
+from .quality import classify_quality, load_thresholds
+
+__all__ = ["classify_quality", "load_thresholds"]

--- a/oracle/calib/calibration.default.yaml
+++ b/oracle/calib/calibration.default.yaml
@@ -1,0 +1,17 @@
+quality_bias:
+  good: 0.3
+  inaccuracy: -0.2
+  mistake: -0.5
+  blunder: -1.0
+  unknown: 0.0
+  mate: 0.4
+
+time_control_bias:
+  bullet: -0.2
+  blitz: -0.05
+  rapid: 0.05
+  classical: 0.1
+
+elo:
+  reference: 1500
+  scale: 0.0005

--- a/oracle/calib/calibrator.py
+++ b/oracle/calib/calibrator.py
@@ -1,0 +1,94 @@
+"""Calibrate LLM move probabilities with chess heuristics."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Iterable, List, Mapping
+
+import yaml
+
+from oracle.core.normalize import normalize_to_pct
+
+DEFAULT_CALIBRATION_PATH = os.path.join(
+    os.path.dirname(__file__), "calibration.default.yaml"
+)
+
+
+def load_config(yaml_path: str | None = None) -> Dict[str, Any]:
+    """Load calibration configuration from YAML."""
+
+    path = yaml_path or os.getenv("ORACLE_CALIBRATION_YAML", DEFAULT_CALIBRATION_PATH)
+    with open(path, "r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle) or {}
+
+
+class Calibrator:
+    """Adjust move probabilities based on external heuristics."""
+
+    def __init__(self, config: Mapping[str, Any] | None = None, yaml_path: str | None = None):
+        if config is None:
+            config = load_config(yaml_path)
+        self.config = config
+
+    def _quality_bias(self, quality: str | None) -> float:
+        mapping = self.config.get("quality_bias", {})
+        return float(mapping.get(quality or "unknown", mapping.get("unknown", 0.0)))
+
+    def _time_bias(self, time_control: str | None) -> float:
+        mapping = self.config.get("time_control_bias", {})
+        if time_control is None:
+            return 0.0
+        return float(mapping.get(time_control, 0.0))
+
+    def _elo_bias(self, elo: int | None) -> float:
+        elo_cfg = self.config.get("elo", {})
+        reference = float(elo_cfg.get("reference", 1500))
+        scale = float(elo_cfg.get("scale", 0.0))
+        if elo is None:
+            return 0.0
+        return (float(elo) - reference) * scale
+
+    def adjust(
+        self,
+        moves: Iterable[Mapping[str, Any]],
+        context: Mapping[str, Any] | None = None,
+    ) -> List[Dict[str, Any]]:
+        """Return calibrated move probabilities."""
+
+        move_list = list(moves)
+        if not move_list:
+            return []
+        context = context or {}
+
+        prior_pairs = [
+            (move["san"], float(move["prior_logprob"])) for move in move_list
+        ]
+        prior_pct = dict(normalize_to_pct(prior_pairs))
+
+        adjusted_pairs = []
+        biases: Dict[str, float] = {}
+        for move in move_list:
+            bias = self._quality_bias(move.get("quality"))
+            bias += self._time_bias(context.get("time_control"))
+            bias += self._elo_bias(context.get("elo"))
+            biases[move["san"]] = bias
+            adjusted_pairs.append((move["san"], float(move["prior_logprob"]) + bias))
+
+        adjusted_pct = dict(normalize_to_pct(adjusted_pairs))
+
+        results: List[Dict[str, Any]] = []
+        for move in move_list:
+            san = move["san"]
+            results.append(
+                {
+                    "san": san,
+                    "prior_logprob": float(move["prior_logprob"]),
+                    "prior_pct": prior_pct[san],
+                    "bias": biases[san],
+                    "adjusted_logprob": float(move["prior_logprob"]) + biases[san],
+                    "adjusted_pct": adjusted_pct[san],
+                    "quality": move.get("quality"),
+                }
+            )
+        return results
+

--- a/oracle/calib/quality.py
+++ b/oracle/calib/quality.py
@@ -1,0 +1,76 @@
+"""Move quality classification helpers."""
+
+from __future__ import annotations
+
+import os
+from typing import Mapping
+
+import yaml
+
+DEFAULT_THRESHOLDS = {
+    "good": 20.0,
+    "inaccuracy": 60.0,
+    "mistake": 200.0,
+    "blunder": 500.0,
+}
+
+ENV_MAPPING = {
+    "good": "ORACLE_QUALITY_GOOD",
+    "inaccuracy": "ORACLE_QUALITY_INACCURACY",
+    "mistake": "ORACLE_QUALITY_MISTAKE",
+    "blunder": "ORACLE_QUALITY_BLUNDER",
+}
+
+ORDER = ["good", "inaccuracy", "mistake", "blunder"]
+
+
+def load_thresholds(
+    env: Mapping[str, str] | None = None,
+    yaml_path: str | None = None,
+) -> Mapping[str, float]:
+    """Load quality thresholds from environment variables or YAML."""
+
+    env_map = env if env is not None else os.environ
+    thresholds = {key: float(value) for key, value in DEFAULT_THRESHOLDS.items()}
+
+    for key, env_key in ENV_MAPPING.items():
+        value = env_map.get(env_key)
+        if value is not None:
+            thresholds[key] = float(value)
+
+    if yaml_path:
+        with open(yaml_path, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+        quality_section = data.get("quality", data)
+        for key in ORDER:
+            if key in quality_section:
+                thresholds[key] = float(quality_section[key])
+
+    previous = 0.0
+    for key in ORDER:
+        thresholds[key] = max(previous, thresholds[key])
+        previous = thresholds[key]
+
+    return thresholds
+
+
+def classify_quality(
+    best_cp: float | None,
+    candidate_cp: float | None,
+    thresholds: Mapping[str, float],
+) -> str:
+    """Classify a move quality bucket based on evaluation delta."""
+
+    if best_cp is None or candidate_cp is None:
+        return "unknown"
+
+    delta = max(0.0, best_cp - candidate_cp)
+
+    if delta <= thresholds.get("good", 0.0):
+        return "good"
+    if delta <= thresholds.get("inaccuracy", thresholds.get("good", 0.0)):
+        return "inaccuracy"
+    if delta <= thresholds.get("mistake", thresholds.get("inaccuracy", 0.0)):
+        return "mistake"
+    return "blunder"
+

--- a/oracle/core/__init__.py
+++ b/oracle/core/__init__.py
@@ -1,0 +1,10 @@
+"""Core utilities for Oracle pipeline."""
+
+from .expected import aggregate_expected_score, expected_score_cp
+from .normalize import normalize_to_pct
+
+__all__ = [
+    "normalize_to_pct",
+    "expected_score_cp",
+    "aggregate_expected_score",
+]

--- a/oracle/core/castling.py
+++ b/oracle/core/castling.py
@@ -1,0 +1,33 @@
+"""Utilities to disambiguate castling moves."""
+
+from __future__ import annotations
+
+import math
+from typing import List, Optional, Tuple
+
+
+_MIN_PROBABILITY = 1e-12
+
+
+def _safe_log(probability: float) -> float:
+    return math.log(max(probability, _MIN_PROBABILITY))
+
+
+def split_castling(
+    move: str, base_logprob: float, continuation_logprob: Optional[float]
+) -> List[Tuple[str, float]]:
+    """Split a castling candidate into short and long variants."""
+
+    if move != "O-O" or continuation_logprob is None:
+        return [(move, base_logprob)]
+
+    base_prob = math.exp(base_logprob)
+    continuation_prob = math.exp(continuation_logprob)
+    continuation_prob = max(0.0, min(1.0, continuation_prob))
+
+    long_prob = base_prob * continuation_prob
+    short_prob = base_prob - long_prob
+    short_prob = max(short_prob, 0.0)
+
+    return [("O-O", _safe_log(short_prob)), ("O-O-O", _safe_log(long_prob))]
+

--- a/oracle/core/expand.py
+++ b/oracle/core/expand.py
@@ -1,0 +1,66 @@
+"""Expansion utilities to build SAN moves from token prefixes."""
+
+from __future__ import annotations
+
+import math
+from typing import List, Set, Tuple
+
+from oracle.llm.base import SequenceProvider
+
+
+def expand_san_candidates(
+    provider: SequenceProvider,
+    prompt: str,
+    legal_moves: Set[str],
+    depth: int,
+    prob_threshold: float,
+    top_k: int,
+) -> List[Tuple[str, float]]:
+    """Expand token prefixes into legal SAN candidates."""
+
+    if not legal_moves or depth <= 0:
+        return []
+
+    min_logprob = math.log(prob_threshold) if prob_threshold > 0 else float("-inf")
+
+    results: List[Tuple[str, float]] = []
+
+    initial_candidates = provider.get_top_sequences(
+        prompt=prompt,
+        legal_moves=list(legal_moves),
+        depth=depth,
+        prob_threshold=prob_threshold,
+        top_k=top_k,
+    )
+
+    def _expand(prefix: str, logprob: float, remaining_depth: int) -> None:
+        if prefix in legal_moves:
+            results.append((prefix, logprob))
+        if remaining_depth <= 0:
+            return
+        next_prompt = f"{prompt}{prefix}"
+        next_candidates = provider.get_top_sequences(
+            prompt=next_prompt,
+            legal_moves=list(legal_moves),
+            depth=remaining_depth,
+            prob_threshold=prob_threshold,
+            top_k=top_k,
+        )
+        for token_text, token_logprob in next_candidates:
+            candidate = f"{prefix}{token_text}"
+            if not any(move.startswith(candidate) for move in legal_moves):
+                continue
+            new_logprob = logprob + token_logprob
+            if new_logprob < min_logprob:
+                continue
+            _expand(candidate, new_logprob, remaining_depth - 1)
+
+    for token_text, token_logprob in initial_candidates:
+        if not any(move.startswith(token_text) for move in legal_moves):
+            continue
+        if token_logprob < min_logprob:
+            continue
+        _expand(token_text, token_logprob, depth - 1)
+
+    return results
+

--- a/oracle/core/expected.py
+++ b/oracle/core/expected.py
@@ -1,0 +1,34 @@
+"""Expected score computations from engine evaluations."""
+
+from __future__ import annotations
+
+import math
+from typing import Iterable, Mapping
+
+
+def expected_score_cp(cp: float, k: float = 0.0035) -> float:
+    """Convert centipawn evaluation to expected score using logistic."""
+
+    return 1.0 / (1.0 + math.exp(-k * cp))
+
+
+def _score_from_move(move: Mapping[str, float]) -> float:
+    if "sf_eval_mate" in move and move["sf_eval_mate"] is not None:
+        mate_value = float(move["sf_eval_mate"])
+        cp_equivalent = 10000.0 if mate_value > 0 else -10000.0
+        return expected_score_cp(cp_equivalent)
+    cp = float(move.get("sf_eval_cp", 0.0))
+    return expected_score_cp(cp)
+
+
+def aggregate_expected_score(moves: Iterable[Mapping[str, float]]) -> float:
+    """Compute weighted expected score across moves."""
+
+    total = 0.0
+    for move in moves:
+        pct = float(move.get("adjusted_pct", 0.0)) / 100.0
+        if pct <= 0:
+            continue
+        total += pct * _score_from_move(move)
+    return total
+

--- a/oracle/core/normalize.py
+++ b/oracle/core/normalize.py
@@ -1,0 +1,25 @@
+"""Normalization helpers for probability distributions."""
+
+from __future__ import annotations
+
+import math
+from typing import List, Tuple
+
+
+def normalize_to_pct(move_logprobs: List[Tuple[str, float]]) -> List[Tuple[str, float]]:
+    """Normalize log probabilities into percentage values."""
+
+    if not move_logprobs:
+        return []
+
+    log_values = [value for _, value in move_logprobs]
+    max_log = max(log_values)
+    exp_sum = sum(math.exp(value - max_log) for value in log_values)
+    factor = 100.0 / exp_sum
+
+    normalized: List[Tuple[str, float]] = []
+    for move, value in move_logprobs:
+        probability = math.exp(value - max_log) * factor
+        normalized.append((move, probability))
+    return normalized
+

--- a/oracle/llm/__init__.py
+++ b/oracle/llm/__init__.py
@@ -1,0 +1,6 @@
+"""LLM provider interfaces and implementations for Oracle."""
+
+from .base import SequenceProvider
+from .selector import build_sequence_provider, get_top_k
+
+__all__ = ["SequenceProvider", "build_sequence_provider", "get_top_k"]

--- a/oracle/llm/base.py
+++ b/oracle/llm/base.py
@@ -1,0 +1,18 @@
+"""LLM provider protocol definitions."""
+
+from typing import List, Protocol, Tuple
+
+
+class SequenceProvider(Protocol):
+    """Protocol describing sequence generation providers."""
+
+    def get_top_sequences(
+        self,
+        prompt: str,
+        legal_moves: List[str],
+        depth: int,
+        prob_threshold: float,
+        top_k: int,
+    ) -> List[Tuple[str, float]]:
+        """Return top sequences with their log probabilities."""
+

--- a/oracle/llm/llama_cpp_local.py
+++ b/oracle/llm/llama_cpp_local.py
@@ -1,0 +1,63 @@
+"""llama.cpp-based local LLM backend."""
+
+from __future__ import annotations
+
+import math
+from typing import List, Tuple
+
+from .base import SequenceProvider
+
+try:  # pragma: no cover - optional dependency import
+    from llama_cpp import Llama
+except Exception:  # pragma: no cover - handled gracefully
+    Llama = None  # type: ignore[misc]
+
+
+def _log_softmax_row(row: List[float]) -> List[float]:
+    max_val = max(row)
+    exp_sum = sum(math.exp(value - max_val) for value in row)
+    return [value - max_val - math.log(exp_sum) for value in row]
+
+
+class LlamaCppLocalProvider(SequenceProvider):
+    """Sequence provider backed by a llama.cpp model."""
+
+    llama_class = Llama
+
+    def __init__(self, model_path: str, llama=None) -> None:
+        if llama is None:
+            if self.llama_class is None:
+                raise ImportError(
+                    "llama_cpp must be installed to use LlamaCppLocalProvider"
+                )
+            llama = self.llama_class(model_path=model_path, logits_all=True)
+        self.model_path = model_path
+        self._llama = llama
+
+    def get_top_sequences(
+        self,
+        prompt: str,
+        legal_moves: List[str],
+        depth: int,
+        prob_threshold: float,
+        top_k: int,
+    ) -> List[Tuple[str, float]]:
+        prompt_bytes = prompt.encode("utf-8")
+        tokens = self._llama.tokenize(prompt_bytes, add_bos=True)
+        self._llama.eval(tokens)
+        logits = self._llama.get_logits()
+        log_probs = _log_softmax_row(list(logits))
+        indexed = list(enumerate(log_probs))
+        indexed.sort(key=lambda item: item[1], reverse=True)
+
+        results: List[Tuple[str, float]] = []
+        for token_id, logprob in indexed:
+            token_bytes = self._llama.detokenize([token_id])
+            token_text = token_bytes.decode("utf-8").strip()
+            if token_text:
+                results.append((token_text, float(logprob)))
+            if len(results) >= top_k:
+                break
+
+        return results
+

--- a/oracle/llm/selector.py
+++ b/oracle/llm/selector.py
@@ -1,0 +1,51 @@
+"""Select appropriate LLM provider based on environment variables."""
+
+from __future__ import annotations
+
+import os
+from typing import Tuple
+
+from .base import SequenceProvider
+from .llama_cpp_local import LlamaCppLocalProvider
+from .transformers_local import TransformersLocalProvider
+
+DEFAULT_TOP_K = 5
+
+
+def _ensure_local_enabled() -> None:
+    use_local = os.getenv("ORACLE_USE_LOCAL", "1")
+    if use_local not in {"1", "true", "True", "YES", "yes"}:
+        raise RuntimeError("Local LLM usage is required but ORACLE_USE_LOCAL is not enabled")
+
+
+def build_sequence_provider() -> SequenceProvider:
+    _ensure_local_enabled()
+    backend = os.getenv("ORACLE_LLM_BACKEND")
+    if not backend:
+        raise RuntimeError("ORACLE_LLM_BACKEND must be set to 'transformers' or 'llama_cpp'")
+
+    backend = backend.lower()
+    if backend == "transformers":
+        model_id = os.getenv("ORACLE_MODEL_ID")
+        if not model_id:
+            raise RuntimeError("ORACLE_MODEL_ID must be set for transformers backend")
+        return TransformersLocalProvider(model_id=model_id)
+    if backend == "llama_cpp":
+        model_path = os.getenv("ORACLE_GGUF_PATH")
+        if not model_path:
+            raise RuntimeError("ORACLE_GGUF_PATH must be set for llama_cpp backend")
+        return LlamaCppLocalProvider(model_path=model_path)
+
+    raise RuntimeError(f"Unsupported ORACLE_LLM_BACKEND: {backend}")
+
+
+def get_top_k(default: int = DEFAULT_TOP_K) -> int:
+    value = os.getenv("ORACLE_TOP_K")
+    if not value:
+        return default
+    try:
+        parsed = int(value)
+    except ValueError as exc:  # pragma: no cover - defensive branch
+        raise RuntimeError("ORACLE_TOP_K must be an integer") from exc
+    return max(1, parsed)
+

--- a/oracle/llm/transformers_local.py
+++ b/oracle/llm/transformers_local.py
@@ -1,0 +1,92 @@
+"""Transformers-based local LLM backend."""
+
+from __future__ import annotations
+
+import math
+from typing import List, Optional, Tuple
+
+from .base import SequenceProvider
+
+try:  # pragma: no cover - optional dependency import
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+except Exception:  # pragma: no cover - handled in code
+    AutoModelForCausalLM = None  # type: ignore
+    AutoTokenizer = None  # type: ignore
+
+
+def _to_numpy(data):
+    if hasattr(data, "detach"):
+        data = data.detach()
+    if hasattr(data, "cpu"):
+        data = data.cpu()
+    if hasattr(data, "numpy"):
+        return data.numpy()
+    return data
+
+
+def _log_softmax_row(row: List[float]) -> List[float]:
+    max_val = max(row)
+    exp_sum = sum(math.exp(value - max_val) for value in row)
+    return [value - max_val - math.log(exp_sum) for value in row]
+
+
+class TransformersLocalProvider(SequenceProvider):
+    """Sequence provider using a local transformers model."""
+
+    def __init__(
+        self,
+        model_id: str,
+        tokenizer=None,
+        model=None,
+        device: Optional[str] = None,
+    ) -> None:
+        if tokenizer is None or model is None:
+            if AutoTokenizer is None or AutoModelForCausalLM is None:
+                raise ImportError(
+                    "transformers must be installed to use TransformersLocalProvider"
+                )
+            tokenizer = AutoTokenizer.from_pretrained(model_id)
+            model = AutoModelForCausalLM.from_pretrained(model_id)
+            if device:
+                model.to(device)
+        self.model_id = model_id
+        self.tokenizer = tokenizer
+        self.model = model
+
+    def get_top_sequences(
+        self,
+        prompt: str,
+        legal_moves: List[str],
+        depth: int,
+        prob_threshold: float,
+        top_k: int,
+    ) -> List[Tuple[str, float]]:
+        encoded = self.tokenizer(prompt, return_tensors="pt")
+        generate_kwargs = {
+            "input_ids": encoded["input_ids"],
+            "attention_mask": encoded.get("attention_mask"),
+            "max_new_tokens": 1,
+            "output_scores": True,
+            "return_dict_in_generate": True,
+            "do_sample": False,
+            "temperature": 0,
+        }
+        outputs = self.model.generate(**generate_kwargs)
+        scores = outputs.scores[0]
+        score_array = _to_numpy(scores)[0]
+
+        log_probs = _log_softmax_row(list(score_array))
+        indexed = list(enumerate(log_probs))
+        indexed.sort(key=lambda item: item[1], reverse=True)
+
+        results: List[Tuple[str, float]] = []
+        for token_id, logprob in indexed[: max(top_k, 0)]:
+            token_text = self.tokenizer.decode([token_id], skip_special_tokens=True)
+            token_text = token_text.strip()
+            if token_text:
+                results.append((token_text, float(logprob)))
+            if len(results) >= top_k:
+                break
+
+        return results
+

--- a/oracle/pipeline/__init__.py
+++ b/oracle/pipeline/__init__.py
@@ -1,0 +1,5 @@
+"""Pipeline entry points for Oracle analysis."""
+
+from .analyze import analyze
+
+__all__ = ["analyze"]

--- a/oracle/pipeline/analyze.py
+++ b/oracle/pipeline/analyze.py
@@ -1,0 +1,129 @@
+"""High-level analysis pipeline combining LLM and Stockfish signals."""
+
+from __future__ import annotations
+
+import io
+from typing import Any, Dict, List, Mapping, Optional
+
+import chess
+import chess.pgn
+
+from oracle.calib.calibrator import Calibrator
+from oracle.calib.quality import classify_quality, load_thresholds
+from oracle.core.expected import aggregate_expected_score
+from oracle.core.expand import expand_san_candidates
+from oracle.llm import selector
+from oracle.sf.adapter import evaluate_moves
+
+
+def _board_from_pgn(pgn: str) -> chess.Board:
+    game = chess.pgn.read_game(io.StringIO(pgn))
+    if game is None:
+        raise ValueError("Invalid PGN supplied for analysis")
+    board = game.board()
+    for move in game.mainline_moves():
+        board.push(move)
+    return board
+
+
+def _evaluation_cp(result: Mapping[str, Any]) -> Optional[float]:
+    if result is None:
+        return None
+    if "mate" in result and result["mate"] is not None:
+        mate = result["mate"]
+        if mate is None:
+            return None
+        return 10000.0 if mate > 0 else -10000.0
+    if "cp" in result and result["cp"] is not None:
+        return float(result["cp"])
+    return None
+
+
+def analyze(
+    pgn: str,
+    ctx: Mapping[str, Any],
+    *,
+    provider=None,
+    engine_factory=None,
+    calibrator: Optional[Calibrator] = None,
+    depth: int = 3,
+    prob_threshold: float = 0.0,
+    top_k: Optional[int] = None,
+    prompt: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Run the full prediction and calibration pipeline."""
+
+    board = _board_from_pgn(pgn)
+    legal_moves = {board.san(move) for move in board.legal_moves}
+
+    if provider is None:
+        provider = selector.build_sequence_provider()
+    if top_k is None:
+        top_k = selector.get_top_k()
+
+    base_prompt = prompt if prompt is not None else pgn
+
+    prior_sequences = expand_san_candidates(
+        provider=provider,
+        prompt=base_prompt,
+        legal_moves=legal_moves,
+        depth=depth,
+        prob_threshold=prob_threshold,
+        top_k=top_k,
+    )
+
+    moves: List[Dict[str, Any]] = [
+        {"san": san, "prior_logprob": logprob} for san, logprob in prior_sequences
+    ]
+
+    engine_results: Dict[str, Mapping[str, Any]] = {}
+    if engine_factory is not None and moves:
+        san_list = [move["san"] for move in moves]
+        engine_results = evaluate_moves(board, san_list, engine_factory)
+
+    thresholds = load_thresholds()
+
+    best_cp: Optional[float] = None
+    for result in engine_results.values():
+        cp_equivalent = _evaluation_cp(result)
+        if cp_equivalent is None:
+            continue
+        if best_cp is None or cp_equivalent > best_cp:
+            best_cp = cp_equivalent
+
+    for move in moves:
+        san = move["san"]
+        eval_result = engine_results.get(san, {})
+        if "cp" in eval_result:
+            move["sf_eval_cp"] = eval_result["cp"]
+        if "mate" in eval_result:
+            move["sf_eval_mate"] = eval_result["mate"]
+        cp_value = _evaluation_cp(eval_result)
+        if best_cp is None or cp_value is None:
+            move["quality"] = "unknown"
+        else:
+            move["quality"] = classify_quality(best_cp, cp_value, thresholds)
+
+    calibrator = calibrator or Calibrator()
+    calibrated = calibrator.adjust(moves, context=ctx)
+
+    move_lookup = {move["san"]: move for move in moves}
+    for entry in calibrated:
+        original = move_lookup.get(entry["san"], {})
+        if "sf_eval_cp" in original:
+            entry["sf_eval_cp"] = original["sf_eval_cp"]
+        if "sf_eval_mate" in original:
+            entry["sf_eval_mate"] = original["sf_eval_mate"]
+        entry["quality"] = original.get("quality", entry.get("quality"))
+
+    expected_score = aggregate_expected_score(calibrated)
+
+    model_name = getattr(provider, "model_id", provider.__class__.__name__)
+
+    return {
+        "model": model_name,
+        "moves": calibrated,
+        "expected_score": expected_score,
+        "usage": {"top_k": top_k, "depth": depth},
+    }
+

--- a/oracle/sf/__init__.py
+++ b/oracle/sf/__init__.py
@@ -1,0 +1,5 @@
+"""Stockfish adapter helpers."""
+
+from .adapter import evaluate_moves
+
+__all__ = ["evaluate_moves"]

--- a/oracle/sf/adapter.py
+++ b/oracle/sf/adapter.py
@@ -1,0 +1,50 @@
+"""Adapter utilities for communicating with Stockfish engines."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Iterable
+
+import chess
+import chess.engine
+
+
+EngineFactory = Callable[[], chess.engine.SimpleEngine]
+
+
+def evaluate_moves(
+    board: chess.Board,
+    san_moves: Iterable[str],
+    engine_factory: Callable[[], chess.engine.SimpleEngine],
+    depth: int = 12,
+) -> Dict[str, Dict[str, int]]:
+    """Evaluate SAN moves using the provided engine factory."""
+
+    results: Dict[str, Dict[str, int]] = {}
+    san_list = list(san_moves)
+    if not san_list:
+        return results
+
+    limit = chess.engine.Limit(depth=depth)
+    with engine_factory() as engine:
+        for san in san_list:
+            analysis_board = board.copy()
+            try:
+                move = analysis_board.parse_san(san)
+            except ValueError:
+                results[san] = {}
+                continue
+            analysis_board.push(move)
+            info = engine.analyse(analysis_board, limit=limit)
+            score: chess.engine.PovScore | None = info.get("score")
+            if score is None:
+                results[san] = {}
+                continue
+            mover_color = not analysis_board.turn
+            pov_score = score.pov(mover_color)
+            if pov_score.is_mate():
+                results[san] = {"mate": pov_score.mate() or 0}
+            else:
+                cp = pov_score.score()
+                results[san] = {"cp": int(cp)}
+    return results
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "chess-prediction"
+version = "0.1.0"
+description = "Local chess move prediction oracle"
+requires-python = ">=3.11"
+dependencies = [
+    "python-chess",
+    "flask",
+    "flask-cors",
+    "pytest",
+    "pytest-cov",
+]
+
+[project.optional-dependencies]
+llm = [
+    "transformers",
+    "accelerate",
+    "llama-cpp-python",
+]
+
+[tool.pytest.ini_options]
+addopts = "--maxfail=1 --disable-warnings"
+pythonpath = ["."]

--- a/tests/calib/test_calibrator.py
+++ b/tests/calib/test_calibrator.py
@@ -1,0 +1,74 @@
+import math
+
+import pytest
+
+from oracle.calib.calibrator import Calibrator
+
+
+def test_calibrator_boosts_good_moves():
+    config = {
+        "quality_bias": {
+            "good": 0.4,
+            "mistake": -0.4,
+            "blunder": -0.8,
+            "unknown": 0.0,
+        },
+        "time_control_bias": {
+            "rapid": 0.0,
+        },
+        "elo": {
+            "reference": 1500,
+            "scale": 0.0,
+        },
+    }
+
+    calibrator = Calibrator(config=config)
+
+    moves = [
+        {"san": "e4", "prior_logprob": math.log(0.6), "quality": "good"},
+        {"san": "d4", "prior_logprob": math.log(0.4), "quality": "mistake"},
+    ]
+
+    results = calibrator.adjust(
+        moves,
+        context={"elo": 1500, "time_control": "rapid"},
+    )
+
+    prior_pct = {item["san"]: item["prior_pct"] for item in results}
+    adjusted_pct = {item["san"]: item["adjusted_pct"] for item in results}
+
+    assert pytest.approx(sum(adjusted_pct.values()), abs=0.1) == 100.0
+    assert adjusted_pct["e4"] > prior_pct["e4"]
+    assert adjusted_pct["d4"] < prior_pct["d4"]
+
+
+def test_calibrator_accounts_for_elo_and_time():
+    config = {
+        "quality_bias": {"good": 0.0, "unknown": 0.0},
+        "time_control_bias": {"bullet": -0.2, "classical": 0.2},
+        "elo": {"reference": 1500, "scale": 0.001},
+    }
+    calibrator = Calibrator(config=config)
+
+    moves = [
+        {"san": "e4", "prior_logprob": math.log(0.5), "quality": "unknown"},
+        {"san": "d4", "prior_logprob": math.log(0.5), "quality": "unknown"},
+    ]
+
+    low_elo = calibrator.adjust(
+        moves,
+        context={"elo": 1000, "time_control": "bullet"},
+    )
+    high_elo = calibrator.adjust(
+        moves,
+        context={"elo": 2000, "time_control": "classical"},
+    )
+
+    low_adjusted = {item["san"]: item["adjusted_pct"] for item in low_elo}
+    high_adjusted = {item["san"]: item["adjusted_pct"] for item in high_elo}
+
+    assert low_adjusted["e4"] == pytest.approx(low_adjusted["d4"], rel=1e-6)
+    assert high_adjusted["e4"] == pytest.approx(high_adjusted["d4"], rel=1e-6)
+
+    assert sum(item["adjusted_pct"] for item in low_elo) == pytest.approx(100.0, abs=0.1)
+    assert sum(item["adjusted_pct"] for item in high_elo) == pytest.approx(100.0, abs=0.1)

--- a/tests/calib/test_quality.py
+++ b/tests/calib/test_quality.py
@@ -1,0 +1,47 @@
+import textwrap
+
+from oracle.calib.quality import classify_quality, load_thresholds
+
+
+def test_classify_quality_uses_default_thresholds():
+    thresholds = load_thresholds(env={})
+
+    assert classify_quality(50, 45, thresholds) == "good"
+    assert classify_quality(50, 0, thresholds) == "inaccuracy"
+    assert classify_quality(50, -120, thresholds) == "mistake"
+    assert classify_quality(50, -400, thresholds) == "blunder"
+
+
+def test_classify_quality_reads_env():
+    env = {
+        "ORACLE_QUALITY_GOOD": "0",
+        "ORACLE_QUALITY_INACCURACY": "10",
+        "ORACLE_QUALITY_MISTAKE": "30",
+        "ORACLE_QUALITY_BLUNDER": "60",
+    }
+
+    thresholds = load_thresholds(env=env)
+
+    assert classify_quality(0, -5, thresholds) == "inaccuracy"
+    assert classify_quality(0, -20, thresholds) == "mistake"
+    assert classify_quality(0, -100, thresholds) == "blunder"
+
+
+def test_classify_quality_reads_yaml(tmp_path):
+    yaml_content = textwrap.dedent(
+        """
+        quality:
+          good: 0
+          inaccuracy: 15
+          mistake: 40
+          blunder: 100
+        """
+    )
+    yaml_file = tmp_path / "quality.yaml"
+    yaml_file.write_text(yaml_content)
+
+    thresholds = load_thresholds(env={}, yaml_path=str(yaml_file))
+
+    assert classify_quality(0, -10, thresholds) == "inaccuracy"
+    assert classify_quality(0, -30, thresholds) == "mistake"
+    assert classify_quality(0, -90, thresholds) == "blunder"

--- a/tests/cli/test_one_move.py
+++ b/tests/cli/test_one_move.py
@@ -1,0 +1,68 @@
+from textwrap import dedent
+import importlib.machinery
+import types
+
+import pytest
+
+
+def _load_module(path: str, name: str):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    module = types.ModuleType(name)
+    loader.exec_module(module)
+    return module
+
+
+cli_one_move = _load_module("Oracle_one_move", "oracle_one_move")
+
+
+@pytest.fixture
+def sample_pgn():
+    return dedent(
+        """
+        [Event "Test"]
+
+        1. e4 e5
+        """
+    ).strip()
+
+
+def test_one_move_cli_outputs_table(sample_pgn, capsys):
+    def fake_analyze(**kwargs):
+        return {
+            "model": "fake",
+            "expected_score": 0.75,
+            "usage": {"top_k": kwargs.get("top_k", 2)},
+            "moves": [
+                {
+                    "san": "Nf3",
+                    "prior_pct": 55.0,
+                    "adjusted_pct": 60.0,
+                    "sf_eval_cp": 80,
+                    "quality": "good",
+                },
+                {
+                    "san": "Nc3",
+                    "prior_pct": 45.0,
+                    "adjusted_pct": 40.0,
+                    "sf_eval_cp": 10,
+                    "quality": "mistake",
+                },
+            ],
+        }
+
+    result = cli_one_move.main(
+        pgn=sample_pgn,
+        analyze_fn=fake_analyze,
+        depth=2,
+        prob_threshold=0.0,
+        top_k=2,
+    )
+
+    captured = capsys.readouterr()
+    output = captured.out
+    assert "Move" in output
+    assert "Prior %" in output
+    assert "Adjusted %" in output
+    assert "Nf3" in output
+    assert "Nc3" in output
+    assert result["expected_score"] == 0.75

--- a/tests/cli/test_pgn_file.py
+++ b/tests/cli/test_pgn_file.py
@@ -1,0 +1,79 @@
+import csv
+import importlib.machinery
+import types
+from pathlib import Path
+from textwrap import dedent
+
+
+def _load_module(path: str, name: str):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    module = types.ModuleType(name)
+    loader.exec_module(module)
+    return module
+
+
+cli_pgn = _load_module("Oracle_pgn_file", "oracle_pgn_file")
+
+
+def test_pgn_file_writes_csv(tmp_path: Path):
+    pgn_content = dedent(
+        """
+        [Event "Game 1"]
+
+        1. e4 e5
+
+        [Event "Game 2"]
+
+        1. d4 d5
+        """
+    ).strip()
+    pgn_path = tmp_path / "games.pgn"
+    pgn_path.write_text(pgn_content)
+    output_path = tmp_path / "out.csv"
+
+    calls = []
+
+    def fake_analyze(**kwargs):
+        calls.append(kwargs["pgn"])
+        return {
+            "model": "fake",
+            "expected_score": 0.5,
+            "usage": {"top_k": kwargs.get("top_k", 2)},
+            "moves": [
+                {
+                    "san": "Nf3",
+                    "prior_pct": 55.0,
+                    "adjusted_pct": 60.0,
+                    "sf_eval_cp": 80,
+                    "quality": "good",
+                }
+            ],
+        }
+
+    cli_pgn.main(
+        pgn_path=str(pgn_path),
+        output_path=str(output_path),
+        analyze_fn=fake_analyze,
+        depth=2,
+        prob_threshold=0.0,
+        top_k=2,
+    )
+
+    assert len(calls) == 2
+
+    with output_path.open() as handle:
+        reader = csv.DictReader(handle)
+        rows = list(reader)
+
+    assert reader.fieldnames == [
+        "game_index",
+        "move_index",
+        "san",
+        "prior_pct",
+        "adjusted_pct",
+        "sf_eval_cp",
+        "quality",
+    ]
+    assert rows[0]["san"] == "Nf3"
+    assert rows[0]["prior_pct"] == "55.0"
+    assert rows[0]["adjusted_pct"] == "60.0"

--- a/tests/core/test_castling.py
+++ b/tests/core/test_castling.py
@@ -1,0 +1,30 @@
+import math
+
+from oracle.core.castling import split_castling
+
+
+def test_split_castling_distributes_mass():
+    base_logprob = math.log(0.5)
+    continuation_logprob = math.log(0.2)
+
+    results = split_castling("O-O", base_logprob, continuation_logprob)
+
+    assert {move for move, _ in results} == {"O-O", "O-O-O"}
+
+    probs = {move: math.exp(lp) for move, lp in results}
+    assert math.isclose(probs["O-O"], 0.4, rel_tol=1e-6)
+    assert math.isclose(probs["O-O-O"], 0.1, rel_tol=1e-6)
+
+
+def test_split_castling_returns_original_when_no_continuation():
+    base_logprob = math.log(0.5)
+    results = split_castling("O-O", base_logprob, None)
+
+    assert results == [("O-O", base_logprob)]
+
+
+def test_split_castling_passthrough_for_other_moves():
+    base_logprob = math.log(0.3)
+    results = split_castling("e4", base_logprob, math.log(0.2))
+
+    assert results == [("e4", base_logprob)]

--- a/tests/core/test_expand_san.py
+++ b/tests/core/test_expand_san.py
@@ -1,0 +1,60 @@
+import math
+
+from oracle.core.expand import expand_san_candidates
+
+
+class FakeProvider:
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    def get_top_sequences(self, prompt, legal_moves, depth, prob_threshold, top_k):
+        return self.mapping.get(prompt, [])
+
+
+def test_expand_san_candidates_accumulates_logprobs():
+    mapping = {
+        "": [("e", math.log(0.6)), ("d", math.log(0.4))],
+        "e": [("4", math.log(0.7)), ("5", math.log(0.3))],
+        "d": [("4", math.log(1.0))],
+    }
+    provider = FakeProvider(mapping)
+    legal_moves = {"e4", "e5", "d4"}
+
+    results = expand_san_candidates(
+        provider=provider,
+        prompt="",
+        legal_moves=legal_moves,
+        depth=2,
+        prob_threshold=0.0,
+        top_k=3,
+    )
+
+    probs = {move: math.exp(logprob) for move, logprob in results}
+    assert math.isclose(probs["e4"], 0.42, rel_tol=1e-6)
+    assert math.isclose(probs["e5"], 0.18, rel_tol=1e-6)
+    assert math.isclose(probs["d4"], 0.4, rel_tol=1e-6)
+
+
+def test_expand_san_prunes_non_matching_prefixes():
+    mapping = {
+        "": [("N", math.log(0.5))],
+        "N": [("f", math.log(0.5)), ("x", math.log(0.5))],
+        "Nf": [("3", math.log(1.0))],
+        "Nx": [("e", math.log(1.0))],
+    }
+    provider = FakeProvider(mapping)
+    legal_moves = {"Nf3"}
+
+    results = expand_san_candidates(
+        provider=provider,
+        prompt="",
+        legal_moves=legal_moves,
+        depth=3,
+        prob_threshold=0.0,
+        top_k=3,
+    )
+
+    assert len(results) == 1
+    move, logprob = results[0]
+    assert move == "Nf3"
+    assert math.isclose(math.exp(logprob), 0.25, rel_tol=1e-6)

--- a/tests/core/test_expected.py
+++ b/tests/core/test_expected.py
@@ -1,0 +1,36 @@
+import math
+
+from oracle.core.expected import aggregate_expected_score, expected_score_cp
+
+
+def test_expected_score_cp_logistic():
+    zero = expected_score_cp(0)
+    positive = expected_score_cp(100)
+    negative = expected_score_cp(-100)
+
+    assert math.isclose(zero, 0.5, rel_tol=1e-6)
+    assert positive > zero
+    assert negative < zero
+
+
+def test_aggregate_expected_score_weights_by_percentage():
+    moves = [
+        {"sf_eval_cp": 100, "adjusted_pct": 60.0},
+        {"sf_eval_cp": -50, "adjusted_pct": 40.0},
+    ]
+
+    expected = aggregate_expected_score(moves)
+
+    assert 0.0 <= expected <= 1.0
+
+    expected_manual = (
+        expected_score_cp(100) * 0.6 + expected_score_cp(-50) * 0.4
+    )
+    assert math.isclose(expected, expected_manual, rel_tol=1e-6)
+
+
+def test_expected_score_handles_mate():
+    moves = [{"sf_eval_mate": 2, "adjusted_pct": 100.0}]
+
+    expected = aggregate_expected_score(moves)
+    assert expected > 0.99

--- a/tests/core/test_normalize.py
+++ b/tests/core/test_normalize.py
@@ -1,0 +1,29 @@
+import math
+
+import pytest
+
+from oracle.core.normalize import normalize_to_pct
+
+
+def test_normalize_to_pct_produces_100_sum():
+    entries = [
+        ("e4", math.log(0.6)),
+        ("d4", math.log(0.3)),
+        ("c4", math.log(0.1)),
+    ]
+
+    normalized = normalize_to_pct(entries)
+
+    total = sum(value for _, value in normalized)
+    assert pytest.approx(total, rel=0, abs=0.1) == 100.0
+
+
+def test_normalize_preserves_order():
+    entries = [
+        ("e4", math.log(0.7)),
+        ("d4", math.log(0.2)),
+        ("c4", math.log(0.1)),
+    ]
+
+    normalized = normalize_to_pct(entries)
+    assert [move for move, _ in normalized] == ["e4", "d4", "c4"]

--- a/tests/e2e/test_pipeline_fake.py
+++ b/tests/e2e/test_pipeline_fake.py
@@ -1,0 +1,105 @@
+import io
+import math
+
+import chess
+import chess.engine
+import chess.pgn
+import pytest
+
+from oracle.calib.calibrator import Calibrator
+from oracle.core.expected import expected_score_cp
+from oracle.pipeline.analyze import analyze
+
+
+class FakeProvider:
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    def get_top_sequences(self, prompt, legal_moves, depth, prob_threshold, top_k):
+        return self.mapping.get(prompt, [])
+
+
+def fake_engine_factory(evaluations):
+    class FakeEngine:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def analyse(self, board, limit):
+            return {"score": evaluations[board.fen()]}
+
+    def factory():
+        return FakeEngine()
+
+    return factory
+
+
+def build_board(pgn: str):
+    game = chess.pgn.read_game(io.StringIO(pgn))
+    board = game.board()
+    for move in game.mainline_moves():
+        board.push(move)
+    return board
+
+
+def test_pipeline_with_fakes(monkeypatch):
+    pgn = "1. e4 e5"
+    board = build_board(pgn)
+
+    mapping = {
+        "": [("N", math.log(1.0))],
+        "N": [("f", math.log(0.6)), ("c", math.log(0.4))],
+        "Nf": [("3", math.log(1.0))],
+        "Nc": [("3", math.log(1.0))],
+    }
+    provider = FakeProvider(mapping)
+
+    nf3_board = board.copy()
+    nf3_board.push_san("Nf3")
+    nc3_board = board.copy()
+    nc3_board.push_san("Nc3")
+
+    evaluations = {
+        nf3_board.fen(): chess.engine.PovScore(chess.engine.Cp(80), chess.WHITE),
+        nc3_board.fen(): chess.engine.PovScore(chess.engine.Cp(10), chess.WHITE),
+    }
+    engine_factory = fake_engine_factory(evaluations)
+
+    config = {
+        "quality_bias": {"good": 0.2, "mistake": -0.4, "unknown": 0.0},
+        "time_control_bias": {"rapid": 0.0},
+        "elo": {"reference": 1500, "scale": 0.0},
+    }
+    calibrator = Calibrator(config=config)
+
+    result = analyze(
+        pgn=pgn,
+        ctx={"elo": 1500, "time_control": "rapid"},
+        provider=provider,
+        engine_factory=engine_factory,
+        calibrator=calibrator,
+        depth=3,
+        prob_threshold=0.0,
+        top_k=2,
+        prompt="",
+    )
+
+    moves = result["moves"]
+    assert len(moves) == 2
+
+    totals = sum(move["adjusted_pct"] for move in moves)
+    assert pytest.approx(totals, abs=0.1) == 100.0
+
+    move_map = {move["san"]: move for move in moves}
+    assert move_map["Nf3"]["adjusted_pct"] > move_map["Nf3"]["prior_pct"]
+    assert move_map["Nc3"]["adjusted_pct"] < move_map["Nc3"]["prior_pct"]
+
+    expected_manual = (
+        move_map["Nf3"]["adjusted_pct"] / 100.0 * expected_score_cp(80)
+        + move_map["Nc3"]["adjusted_pct"] / 100.0 * expected_score_cp(10)
+    )
+    assert math.isclose(result["expected_score"], expected_manual, rel_tol=1e-6)
+
+    assert result["usage"]["top_k"] == 2

--- a/tests/llm/test_llama_cpp_adapter.py
+++ b/tests/llm/test_llama_cpp_adapter.py
@@ -1,0 +1,57 @@
+import math
+
+import pytest
+
+from oracle.llm.llama_cpp_local import LlamaCppLocalProvider
+
+
+class FakeLlama:
+    def __init__(self, model_path: str, logits_all: bool = False):
+        assert logits_all
+        self.model_path = model_path
+        self.last_prompt = None
+        self.last_tokens = None
+
+    def tokenize(self, prompt: bytes, add_bos: bool = True):
+        assert add_bos
+        self.last_prompt = prompt
+        return [101, 102]
+
+    def eval(self, tokens, n_past=0):  # noqa: D401 - mimic llama signature
+        self.last_tokens = tokens
+        return None
+
+    def get_logits(self):
+        return [2.0, 1.0, 0.0]
+
+    def detokenize(self, token_ids):
+        mapping = {
+            0: b"e4",
+            1: b"d4",
+            2: b"c4",
+        }
+        return mapping[token_ids[0]]
+
+
+def test_llama_cpp_provider_returns_logprobs():
+    fake_llama = FakeLlama("fake.gguf", logits_all=True)
+    provider = LlamaCppLocalProvider(model_path="fake.gguf", llama=fake_llama)
+
+    results = provider.get_top_sequences(
+        prompt="1. e4",
+        legal_moves=["e4", "d4", "c4"],
+        depth=1,
+        prob_threshold=0.0,
+        top_k=2,
+    )
+
+    assert [move for move, _ in results] == ["e4", "d4"]
+
+    exp_values = [math.exp(v) for v in [2.0, 1.0, 0.0]]
+    total = sum(exp_values)
+    expected_logprobs = [math.log(exp_values[i] / total) for i in range(2)]
+    for (_, logprob), expected in zip(results, expected_logprobs):
+        assert logprob == pytest.approx(expected, rel=1e-6)
+
+    assert fake_llama.last_prompt == "1. e4".encode("utf-8")
+    assert fake_llama.last_tokens == [101, 102]

--- a/tests/llm/test_provider_contract.py
+++ b/tests/llm/test_provider_contract.py
@@ -1,0 +1,31 @@
+import math
+from typing import List, Tuple
+
+import pytest
+
+from oracle.llm.base import SequenceProvider
+
+
+class FakeProvider:
+    def get_top_sequences(
+        self,
+        prompt: str,
+        legal_moves: List[str],
+        depth: int,
+        prob_threshold: float,
+        top_k: int,
+    ) -> List[Tuple[str, float]]:
+        return [("e4", math.log(0.9)), ("d4", math.log(0.1))]
+
+
+def test_fake_provider_matches_protocol() -> None:
+    provider: SequenceProvider
+    provider = FakeProvider()
+
+    results = provider.get_top_sequences("Prompt", ["e4", "d4"], 1, 0.05, 2)
+
+    assert isinstance(results, list)
+    assert all(isinstance(item, tuple) for item in results)
+    assert all(len(item) == 2 for item in results)
+    assert all(isinstance(item[0], str) for item in results)
+    assert all(isinstance(item[1], float) for item in results)

--- a/tests/llm/test_selector.py
+++ b/tests/llm/test_selector.py
@@ -1,0 +1,64 @@
+import pytest
+
+from oracle.llm import selector
+
+
+class DummyTransformersProvider:
+    def __init__(self, model_id: str):
+        self.model_id = model_id
+
+
+class DummyLlamaProvider:
+    def __init__(self, model_path: str):
+        self.model_path = model_path
+
+
+def test_selector_returns_transformers_provider(monkeypatch):
+    monkeypatch.setenv("ORACLE_USE_LOCAL", "1")
+    monkeypatch.setenv("ORACLE_LLM_BACKEND", "transformers")
+    monkeypatch.setenv("ORACLE_MODEL_ID", "dummy-model")
+
+    monkeypatch.setattr(
+        selector, "TransformersLocalProvider", DummyTransformersProvider
+    )
+
+    provider = selector.build_sequence_provider()
+    assert isinstance(provider, DummyTransformersProvider)
+    assert provider.model_id == "dummy-model"
+
+
+def test_selector_returns_llama_provider(monkeypatch):
+    monkeypatch.setenv("ORACLE_USE_LOCAL", "1")
+    monkeypatch.setenv("ORACLE_LLM_BACKEND", "llama_cpp")
+    monkeypatch.setenv("ORACLE_GGUF_PATH", "/tmp/fake.gguf")
+
+    monkeypatch.setattr(selector, "LlamaCppLocalProvider", DummyLlamaProvider)
+
+    provider = selector.build_sequence_provider()
+    assert isinstance(provider, DummyLlamaProvider)
+    assert provider.model_path == "/tmp/fake.gguf"
+
+
+def test_selector_requires_backend(monkeypatch):
+    monkeypatch.delenv("ORACLE_LLM_BACKEND", raising=False)
+    monkeypatch.setenv("ORACLE_USE_LOCAL", "1")
+
+    with pytest.raises(RuntimeError):
+        selector.build_sequence_provider()
+
+
+def test_selector_requires_model_id(monkeypatch):
+    monkeypatch.setenv("ORACLE_USE_LOCAL", "1")
+    monkeypatch.setenv("ORACLE_LLM_BACKEND", "transformers")
+    monkeypatch.delenv("ORACLE_MODEL_ID", raising=False)
+
+    with pytest.raises(RuntimeError):
+        selector.build_sequence_provider()
+
+
+def test_selector_unknown_backend(monkeypatch):
+    monkeypatch.setenv("ORACLE_USE_LOCAL", "1")
+    monkeypatch.setenv("ORACLE_LLM_BACKEND", "unknown")
+
+    with pytest.raises(RuntimeError):
+        selector.build_sequence_provider()

--- a/tests/llm/test_transformers_local_mock.py
+++ b/tests/llm/test_transformers_local_mock.py
@@ -1,0 +1,97 @@
+import math
+from types import SimpleNamespace
+
+import pytest
+
+from oracle.llm.transformers_local import TransformersLocalProvider
+
+
+class DummyTensor:
+    def __init__(self, data):
+        self._data = data
+
+    def detach(self):
+        return self
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self._data
+
+
+class DummyTokenizer:
+    def __init__(self):
+        self.decode_map = {
+            0: "e4",
+            1: "d4",
+            2: "c4",
+        }
+
+    def __call__(self, prompt: str, return_tensors: str):
+        assert prompt == "Prompt"
+        assert return_tensors == "pt"
+        return {"input_ids": [[1, 2, 3]]}
+
+    def decode(self, token_ids, skip_special_tokens=True):
+        assert skip_special_tokens
+        (token_id,) = token_ids
+        return self.decode_map[token_id]
+
+
+class DummyModel:
+    def __init__(self):
+        self.seen_kwargs = None
+
+    def generate(self, **kwargs):
+        self.seen_kwargs = kwargs
+        scores = DummyTensor([[2.0, 1.0, 0.0]])
+        return SimpleNamespace(
+            sequences=[[1, 2, 3, 0]],
+            scores=[scores],
+        )
+
+
+class DummyTokenizerWrapper(DummyTokenizer):
+    def convert_ids_to_tokens(self, token_id):
+        return self.decode_map[token_id]
+
+
+@pytest.fixture
+def provider():
+    dummy_tokenizer = DummyTokenizerWrapper()
+    dummy_model = DummyModel()
+
+    provider = TransformersLocalProvider(
+        model_id="dummy",
+        tokenizer=dummy_tokenizer,
+        model=dummy_model,
+    )
+
+    return provider, dummy_model
+
+
+def test_transformers_provider_returns_sorted_logprobs(provider):
+    provider_instance, dummy_model = provider
+    results = provider_instance.get_top_sequences(
+        prompt="Prompt",
+        legal_moves=["e4", "d4", "c4"],
+        depth=1,
+        prob_threshold=0.0,
+        top_k=2,
+    )
+
+    assert len(results) == 2
+    assert [move for move, _ in results] == ["e4", "d4"]
+
+    exp_values = [math.exp(v) for v in [2.0, 1.0, 0.0]]
+    total = sum(exp_values)
+    expected_logprobs = [math.log(exp_values[i] / total) for i in range(2)]
+    for (_, logprob), expected in zip(results, expected_logprobs):
+        assert pytest.approx(logprob, rel=1e-6) == expected
+
+    assert dummy_model.seen_kwargs["do_sample"] is False
+    assert dummy_model.seen_kwargs["temperature"] == 0
+    assert dummy_model.seen_kwargs["max_new_tokens"] == 1
+    assert dummy_model.seen_kwargs["output_scores"] is True
+    assert dummy_model.seen_kwargs["return_dict_in_generate"] is True

--- a/tests/sf/test_adapter.py
+++ b/tests/sf/test_adapter.py
@@ -1,0 +1,69 @@
+import chess
+import chess.engine
+
+from oracle.sf.adapter import evaluate_moves
+
+
+class FakeEngine:
+    def __init__(self, evaluations):
+        self.evaluations = evaluations
+        self.calls = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def analyse(self, board, limit):
+        fen = board.fen()
+        self.calls.append(fen)
+        score = self.evaluations[fen]
+        return {"score": score}
+
+    def quit(self):  # pragma: no cover - compatibility
+        pass
+
+
+def fake_engine_factory(evaluations):
+    def _factory():
+        return FakeEngine(evaluations)
+
+    return _factory
+
+
+def test_evaluate_moves_returns_cp_scores():
+    board = chess.Board()
+    e4_board = board.copy()
+    e4_board.push_san("e4")
+    d4_board = board.copy()
+    d4_board.push_san("d4")
+
+    evaluations = {
+        e4_board.fen(): chess.engine.PovScore(chess.engine.Cp(50), chess.WHITE),
+        d4_board.fen(): chess.engine.PovScore(chess.engine.Cp(-20), chess.WHITE),
+    }
+
+    factory = fake_engine_factory(evaluations)
+
+    results = evaluate_moves(board, ["e4", "d4"], factory, depth=10)
+
+    assert results["e4"]["cp"] == 50
+    assert results["d4"]["cp"] == -20
+    assert results["e4"].get("mate") is None
+
+
+def test_evaluate_moves_handles_mate_scores():
+    board = chess.Board()
+    mate_board = board.copy()
+    mate_board.push_san("e4")
+
+    evaluations = {
+        mate_board.fen(): chess.engine.PovScore(chess.engine.Mate(2), chess.WHITE)
+    }
+    factory = fake_engine_factory(evaluations)
+
+    results = evaluate_moves(board, ["e4"], factory, depth=10)
+
+    assert results["e4"]["mate"] == 2
+    assert "cp" not in results["e4"]

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -1,0 +1,5 @@
+import math
+
+
+def test_truth():
+    assert math.isfinite(1.0)

--- a/tests/web/test_api_analyze.py
+++ b/tests/web/test_api_analyze.py
@@ -1,0 +1,43 @@
+import json
+
+import Oracle_web as web_app
+
+
+def test_api_analyze_returns_expected_json():
+    def fake_analyze(**kwargs):
+        assert kwargs["pgn"].startswith("1. e4")
+        assert kwargs["ctx"] == {"elo": 1500, "time_control": "rapid"}
+        return {
+            "model": "fake",
+            "expected_score": 0.75,
+            "usage": {"top_k": 2},
+            "moves": [
+                {
+                    "san": "Nf3",
+                    "prior_pct": 55.0,
+                    "adjusted_pct": 60.0,
+                    "sf_eval_cp": 80,
+                    "quality": "good",
+                }
+            ],
+        }
+
+    app = web_app.create_app(analyze_fn=fake_analyze)
+    client = app.test_client()
+
+    payload = {
+        "pgn": "1. e4 e5",
+        "context": {"elo": 1500, "time_control": "rapid"},
+    }
+    response = client.post(
+        "/api/analyze",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["model"] == "fake"
+    assert data["expected_score"] == 0.75
+    assert data["moves"][0]["san"] == "Nf3"
+    assert response.headers["Access-Control-Allow-Origin"] == "http://localhost:5173"


### PR DESCRIPTION
## Summary
- add modular local LLM interfaces (transformers and llama.cpp) with selector
- implement normalization, expansion, stockfish adapter, calibration, and expected score helpers
- build pipeline analyze entry point plus CLI and Flask web API using the new infrastructure
- add comprehensive pytest suite covering llm providers, core logic, pipeline, CLI, and web API

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d32f603f08832791e0b8179c6901db