### PR TITLE
Allow configuring Stockfish path from web UI

### DIFF
--- a/Oracle_one_move
+++ b/Oracle_one_move
@@ -16,7 +16,7 @@ DEFAULT_TIME_CONTROL = "classical"
 
 
 def _read_pgn_from_input() -> str:
-    print('Enter the PGN (finish with an empty line or EOF):')
+    print("Enter the PGN (finish with an empty line or EOF):")
     lines = []
     try:
         while True:

--- a/Oracle_pgn_file
+++ b/Oracle_pgn_file
@@ -33,7 +33,9 @@ def _iterate_games(path: str) -> Iterable[str]:
             game = chess.pgn.read_game(handle)
             if game is None:
                 break
-            exporter = chess.pgn.StringExporter(headers=True, variations=False, comments=False)
+            exporter = chess.pgn.StringExporter(
+                headers=True, variations=False, comments=False
+            )
             game.accept(exporter)
             yield str(exporter)
 

--- a/Oracle_web.py
+++ b/Oracle_web.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import os
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict
 
+import chess.engine
 from flask import Flask, jsonify, request
 from flask_cors import CORS
 
@@ -12,6 +13,96 @@ from oracle.pipeline.analyze import analyze as default_analyze
 
 DEFAULT_ELO = 1500
 DEFAULT_TIME_CONTROL = "classical"
+DEFAULT_STOCKFISH_PATH = os.getenv("STOCKFISH_PATH", "")
+
+INDEX_HTML_TEMPLATE = """<!doctype html>
+<html lang='en'>
+<head>
+  <meta charset='utf-8'>
+  <title>Oracle Analyzer</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    textarea { width: 100%; height: 200px; }
+    table { border-collapse: collapse; margin-top: 1rem; width: 100%; }
+    th, td { border: 1px solid #ccc; padding: 0.5rem; text-align: left; }
+    .controls { margin-top: 0.75rem; display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center; }
+    .controls label { font-weight: bold; }
+    .controls input, .controls select { padding: 0.3rem; }
+    .stockfish { flex: 1 1 100%; display: flex; flex-direction: column; }
+    .stockfish input { width: 100%; box-sizing: border-box; }
+  </style>
+</head>
+<body>
+  <h1>Oracle Analyzer</h1>
+  <label for='pgn'>PGN</label><br>
+  <textarea id='pgn'></textarea>
+  <div class='controls'>
+    <label for='elo'>Elo:</label>
+    <input id='elo' type='number' value='1500'>
+    <label for='time_control'>Time Control:</label>
+    <select id='time_control'>
+      <option value='bullet'>bullet</option>
+      <option value='blitz'>blitz</option>
+      <option value='rapid' selected>rapid</option>
+      <option value='classical'>classical</option>
+    </select>
+    <div class='stockfish'>
+      <label for='stockfish_path'>Stockfish Path:</label>
+      <input id='stockfish_path' type='text' placeholder='/usr/local/bin/stockfish' value='__STOCKFISH_PATH__'>
+    </div>
+    <button onclick='analyze()'>Analyze</button>
+  </div>
+  <div id='result'></div>
+<script>
+async function analyze() {
+  const stockfishPath = document.getElementById('stockfish_path').value.trim();
+  const payload = {
+    pgn: document.getElementById('pgn').value,
+    context: {
+      elo: parseInt(document.getElementById('elo').value, 10),
+      time_control: document.getElementById('time_control').value
+    },
+    stockfish_path: stockfishPath
+  };
+  const response = await fetch('/api/analyze', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  const container = document.getElementById('result');
+  if (!response.ok) {
+    let errorMessage = 'Request failed';
+    try {
+      const errorPayload = await response.json();
+      if (errorPayload && errorPayload.error) {
+        errorMessage = errorPayload.error;
+      }
+    } catch (err) {
+      // ignore parsing errors and fall back to default message
+    }
+    container.innerHTML = `<p>${errorMessage}</p>`;
+    return;
+  }
+  const data = await response.json();
+  let html = `<p>Expected score: ${data.expected_score.toFixed(3)}</p>`;
+  html += '<table><thead><tr><th>Move</th><th>Prior %</th><th>Adjusted %</th><th>SF Eval</th><th>Quality</th></tr></thead><tbody>';
+  for (const move of data.moves) {
+    html += `<tr><td>${move.san}</td><td>${move.prior_pct.toFixed(2)}</td><td>${move.adjusted_pct.toFixed(2)}</td><td>${move.sf_eval_cp ?? ''}</td><td>${move.quality ?? ''}</td></tr>`;
+  }
+  html += '</tbody></table>';
+  container.innerHTML = html;
+}
+</script>
+</body>
+</html>
+"""
+
+
+def _make_engine_factory(path: str) -> Callable[[], chess.engine.SimpleEngine]:
+    def factory() -> chess.engine.SimpleEngine:
+        return chess.engine.SimpleEngine.popen_uci(path)
+
+    return factory
 
 
 def _normalize_time_control(value: str) -> str:
@@ -28,7 +119,9 @@ def _parse_context(payload: Dict[str, object]) -> Dict[str, object]:
         elo = int(elo_value) if elo_value is not None else DEFAULT_ELO
     except (TypeError, ValueError):
         elo = DEFAULT_ELO
-    time_control = _normalize_time_control(context.get("time_control", DEFAULT_TIME_CONTROL))
+    time_control = _normalize_time_control(
+        context.get("time_control", DEFAULT_TIME_CONTROL)
+    )
     return {"elo": elo, "time_control": time_control}
 
 
@@ -43,74 +136,26 @@ def create_app(analyze_fn: Callable[..., Dict[str, object]] = default_analyze) -
         if not pgn:
             return jsonify({"error": "Missing PGN"}), 400
         ctx = _parse_context(payload)
-        result = analyze_fn(pgn=pgn, ctx=ctx)
+        stockfish_path = (payload.get("stockfish_path") or "").strip()
+        engine_factory = (
+            _make_engine_factory(stockfish_path) if stockfish_path else None
+        )
+        try:
+            result = analyze_fn(pgn=pgn, ctx=ctx, engine_factory=engine_factory)
+        except (FileNotFoundError, chess.engine.EngineError) as exc:
+            app.logger.exception("Stockfish engine error", exc_info=exc)
+            return (
+                jsonify({"error": "Le chemin Stockfish est invalide ou inaccessible."}),
+                400,
+            )
+        except Exception as exc:  # noqa: BLE001
+            app.logger.exception("Analysis failed", exc_info=exc)
+            return jsonify({"error": "Erreur interne lors de l'analyse."}), 500
         return jsonify(result)
 
     @app.get("/")
     def index():
-        return (
-            """<!doctype html>
-<html lang='en'>
-<head>
-  <meta charset='utf-8'>
-  <title>Oracle Analyzer</title>
-  <style>
-    body { font-family: Arial, sans-serif; margin: 2rem; }
-    textarea { width: 100%; height: 200px; }
-    table { border-collapse: collapse; margin-top: 1rem; width: 100%; }
-    th, td { border: 1px solid #ccc; padding: 0.5rem; text-align: left; }
-  </style>
-</head>
-<body>
-  <h1>Oracle Analyzer</h1>
-  <label for='pgn'>PGN</label><br>
-  <textarea id='pgn'></textarea>
-  <div>
-    <label for='elo'>Elo:</label>
-    <input id='elo' type='number' value='1500'>
-    <label for='time_control'>Time Control:</label>
-    <select id='time_control'>
-      <option value='bullet'>bullet</option>
-      <option value='blitz'>blitz</option>
-      <option value='rapid' selected>rapid</option>
-      <option value='classical'>classical</option>
-    </select>
-    <button onclick='analyze()'>Analyze</button>
-  </div>
-  <div id='result'></div>
-<script>
-async function analyze() {
-  const payload = {
-    pgn: document.getElementById('pgn').value,
-    context: {
-      elo: parseInt(document.getElementById('elo').value, 10),
-      time_control: document.getElementById('time_control').value
-    }
-  };
-  const response = await fetch('/api/analyze', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload)
-  });
-  const container = document.getElementById('result');
-  if (!response.ok) {
-    container.innerHTML = '<p>Request failed</p>';
-    return;
-  }
-  const data = await response.json();
-  let html = `<p>Expected score: ${data.expected_score.toFixed(3)}</p>`;
-  html += '<table><thead><tr><th>Move</th><th>Prior %</th><th>Adjusted %</th><th>SF Eval</th><th>Quality</th></tr></thead><tbody>';
-  for (const move of data.moves) {
-    html += `<tr><td>${move.san}</td><td>${move.prior_pct.toFixed(2)}</td><td>${move.adjusted_pct.toFixed(2)}</td><td>${move.sf_eval_cp ?? ''}</td><td>${move.quality ?? ''}</td></tr>`;
-  }
-  html += '</tbody></table>';
-  container.innerHTML = html;
-}
-</script>
-</body>
-</html>
-"""
-        )
+        return INDEX_HTML_TEMPLATE.replace("__STOCKFISH_PATH__", DEFAULT_STOCKFISH_PATH)
 
     return app
 

--- a/oracle/interfaces/web/templates/index.html
+++ b/oracle/interfaces/web/templates/index.html
@@ -8,7 +8,7 @@
         header { margin-bottom: 1.5rem; }
         form { background: #fff; padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.1); }
         textarea { width: 100%; height: 160px; font-family: monospace; }
-        input[type="number"], select { width: 100%; padding: 0.5rem; }
+        input[type="number"], input[type="text"], select { width: 100%; padding: 0.5rem; }
         .field { margin-bottom: 1rem; }
         button { padding: 0.6rem 1.2rem; background-color: #005bbb; color: #fff; border: none; border-radius: 4px; cursor: pointer; }
         button:hover { background-color: #004a94; }
@@ -21,8 +21,8 @@
 </head>
 <body>
     <header>
-        <h1>Oracle – Interface Web</h1>
-        <p>Soumettez un PGN pour obtenir les coups probables et les évaluations d'Oracle.</p>
+        <h1>Oracle Â– Interface Web</h1>
+        <p>Soumettez un PGN pour obtenir les coups probables et les Ã©valuations d'Oracle.</p>
     </header>
     <section>
         <form method="post">
@@ -51,8 +51,12 @@
                 <input id="depth" name="depth" type="number" min="1" max="7" value="{{ form_data.depth }}" />
             </div>
             <div class="field">
-                <label for="prob_threshold">Seuil de probabilité</label>
+                <label for="prob_threshold">Seuil de probabilitÃ©</label>
                 <input id="prob_threshold" name="prob_threshold" type="number" step="0.0001" min="0.0001" max="0.1" value="{{ form_data.prob_threshold }}" />
+            </div>
+            <div class="field">
+                <label for="stockfish_path">Chemin vers Stockfish</label>
+                <input id="stockfish_path" name="stockfish_path" type="text" placeholder="/usr/local/bin/stockfish" value="{{ form_data.stockfish_path }}" />
             </div>
             <button type="submit">Analyser</button>
         </form>
@@ -63,9 +67,9 @@
     {% if report %}
         <section class="metrics">
             <p><strong>Temps total :</strong> {{ report.elapsed_seconds|round(2) }} s</p>
-            <p><strong>Évaluation courante :</strong> {{ report.current_win_percentage|round(2) }}%</p>
+            <p><strong>Ã‰valuation courante :</strong> {{ report.current_win_percentage|round(2) }}%</p>
             <p><strong>Jetons :</strong> {{ report.usage.input_tokens }} in / {{ report.usage.output_tokens }} out</p>
-            <p><strong>Coût estimé :</strong> ${{ report.usage.cost_usd|round(4) }}</p>
+            <p><strong>CoÃ»t estimÃ© :</strong> ${{ report.usage.cost_usd|round(4) }}</p>
         </section>
         <section>
             <table>
@@ -73,8 +77,8 @@
                     <tr>
                         <th>#</th>
                         <th>Coup</th>
-                        <th>Probabilité</th>
-                        <th>Évaluation</th>
+                        <th>ProbabilitÃ©</th>
+                        <th>Ã‰valuation</th>
                         <th>Perte %</th>
                         <th>Notation</th>
                     </tr>

--- a/tests/web/test_api_analyze.py
+++ b/tests/web/test_api_analyze.py
@@ -41,3 +41,54 @@ def test_api_analyze_returns_expected_json():
     assert data["expected_score"] == 0.75
     assert data["moves"][0]["san"] == "Nf3"
     assert response.headers["Access-Control-Allow-Origin"] == "http://localhost:5173"
+
+
+def test_api_analyze_accepts_stockfish_path(monkeypatch):
+    captured_paths = []
+
+    class DummyEngine:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def quit(self):
+            pass
+
+    def fake_make_engine_factory(path):
+        def factory():
+            captured_paths.append(path)
+            return DummyEngine()
+
+        return factory
+
+    def fake_analyze(**kwargs):
+        engine_factory = kwargs.get("engine_factory")
+        assert engine_factory is not None
+        with engine_factory():
+            pass
+        return {
+            "model": "fake",
+            "expected_score": 0.5,
+            "usage": {"top_k": 2},
+            "moves": [],
+        }
+
+    monkeypatch.setattr(web_app, "_make_engine_factory", fake_make_engine_factory)
+    app = web_app.create_app(analyze_fn=fake_analyze)
+    client = app.test_client()
+
+    payload = {
+        "pgn": "1. e4 e5",
+        "context": {"elo": 1500, "time_control": "rapid"},
+        "stockfish_path": "/custom/stockfish",
+    }
+    response = client.post(
+        "/api/analyze",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    assert captured_paths == ["/custom/stockfish"]

--- a/tests/web/test_web_stockfish_selection.py
+++ b/tests/web/test_web_stockfish_selection.py
@@ -1,0 +1,152 @@
+from oracle.config import Settings
+from oracle.domain.models import MovePrediction, PredictionReport
+import oracle.interfaces.web.app as web_app
+
+
+def _dummy_report() -> PredictionReport:
+    return PredictionReport(
+        rows=[
+            MovePrediction(
+                move="Nf3",
+                raw_probability=0.1,
+                normalized_probability=55.0,
+                win_percentage=60.0,
+                percentage_loss=5.0,
+            )
+        ],
+        current_win_percentage=60.0,
+        elapsed_seconds=0.2,
+    )
+
+
+def test_stockfish_path_override_in_form(monkeypatch):
+    created_paths: list[str] = []
+
+    def fake_create_single_move_predictor(settings: Settings):
+        created_paths.append(settings.stockfish_path)
+
+        class _Predictor:
+            def predict(self, context, depth, prob_threshold):  # noqa: ANN001
+                return _dummy_report()
+
+        return _Predictor()
+
+    base_settings = Settings(
+        openai_api_key="key",
+        stockfish_path="/default/stockfish",
+        model_name="model",
+        time_limit=0.5,
+        depth=3,
+        threads=1,
+        hash_size=128,
+    )
+
+    monkeypatch.setattr(
+        web_app, "create_single_move_predictor", fake_create_single_move_predictor
+    )
+    monkeypatch.setattr(web_app, "load_settings", lambda: base_settings)
+
+    app = web_app.create_app()
+    client = app.test_client()
+
+    response = client.post(
+        "/",
+        data={
+            "pgn": "1. e4 e5 2. Nf3 Nc6",
+            "white_elo": "2000",
+            "black_elo": "2100",
+            "game_type": "rapid",
+            "depth": "3",
+            "prob_threshold": "0.01",
+            "stockfish_path": "/custom/stockfish",
+        },
+    )
+
+    assert response.status_code == 200
+    assert "/custom/stockfish" in created_paths
+    assert "/default/stockfish" not in created_paths
+
+
+def test_stockfish_path_falls_back_to_settings(monkeypatch):
+    created_paths: list[str] = []
+
+    def fake_create_single_move_predictor(settings: Settings):
+        created_paths.append(settings.stockfish_path)
+
+        class _Predictor:
+            def predict(self, context, depth, prob_threshold):  # noqa: ANN001
+                return _dummy_report()
+
+        return _Predictor()
+
+    base_settings = Settings(
+        openai_api_key="key",
+        stockfish_path="/configured/stockfish",
+        model_name="model",
+        time_limit=0.5,
+        depth=3,
+        threads=1,
+        hash_size=128,
+    )
+
+    monkeypatch.setattr(
+        web_app, "create_single_move_predictor", fake_create_single_move_predictor
+    )
+    monkeypatch.setattr(web_app, "load_settings", lambda: base_settings)
+
+    app = web_app.create_app()
+    client = app.test_client()
+
+    response = client.post(
+        "/",
+        data={
+            "pgn": "1. e4 e5 2. Nf3 Nc6",
+            "white_elo": "2000",
+            "black_elo": "2100",
+            "game_type": "rapid",
+            "depth": "3",
+            "prob_threshold": "0.01",
+            "stockfish_path": "",
+        },
+    )
+
+    assert response.status_code == 200
+    assert created_paths == ["/configured/stockfish"]
+
+
+def test_missing_stockfish_path_shows_error(monkeypatch):
+    base_settings = Settings(
+        openai_api_key="key",
+        stockfish_path="",
+        model_name="model",
+        time_limit=0.5,
+        depth=3,
+        threads=1,
+        hash_size=128,
+    )
+
+    monkeypatch.setattr(web_app, "load_settings", lambda: base_settings)
+
+    def _fail(_settings):  # noqa: ANN001
+        raise AssertionError("Predictor should not be created")
+
+    monkeypatch.setattr(web_app, "create_single_move_predictor", _fail)
+
+    app = web_app.create_app()
+    client = app.test_client()
+
+    response = client.post(
+        "/",
+        data={
+            "pgn": "1. e4 e5 2. Nf3 Nc6",
+            "white_elo": "2000",
+            "black_elo": "2100",
+            "game_type": "rapid",
+            "depth": "3",
+            "prob_threshold": "0.01",
+            "stockfish_path": "",
+        },
+    )
+
+    assert response.status_code == 200
+    assert "chemin de Stockfish" in response.get_data(as_text=True)


### PR DESCRIPTION
## Summary
- add a Stockfish path field to the lightweight Oracle_web UI, propagate it to the backend, and surface friendly errors when the engine cannot be started
- extend the templated Flask interface to accept a user-provided Stockfish path with validation, caching, and localisation updates
- cover the new behaviour with web tests exercising engine factory wiring and form handling

## Testing
- python -m black Oracle_web.py oracle/interfaces/web/app.py tests/web/test_api_analyze.py tests/web/test_web_stockfish_selection.py
- python -m black Oracle_one_move Oracle_pgn_file
- pytest -q

## Configuration
- [x] Added ability to override the Stockfish binary path from the web interfaces (defaults to STOCKFISH_PATH if left blank)


------
https://chatgpt.com/codex/tasks/task_e_68d336b6a4fc8327b4f312566aaa524f