### PR TITLE
Add Hugging Face serverless fallback chain and docs

### DIFF
--- a/Oracle_web.py
+++ b/Oracle_web.py
@@ -36,12 +36,13 @@ DEFAULT_LLM_BACKEND = os.getenv("ORACLE_LLM_BACKEND", "")
 DEFAULT_LLM_PROVIDER = os.getenv("ORACLE_LLM_PROVIDER", DEFAULT_LLM_BACKEND)
 DEFAULT_TRANSFORMERS_MODEL_ID = os.getenv("ORACLE_MODEL_ID", "")
 DEFAULT_LLAMA_MODEL_PATH = os.getenv("ORACLE_GGUF_PATH", "")
+DEFAULT_HF_MODEL_CANDIDATES = os.getenv("HF_MODEL_CANDIDATES", "")
 
 try:
     _HF_DEFAULTS = load_hf_settings_from_env()
 except RuntimeError:
     _HF_DEFAULTS = {
-        "model_id": "mistralai/Mistral-7B-Instruct-v0.2",
+        "model_id": "HuggingFaceH4/zephyr-7b-beta",
         "api_token": None,
         "top_n_tokens": 10,
         "temperature": 0.0,
@@ -138,7 +139,7 @@ INDEX_HTML_TEMPLATE = """<!doctype html>
     </div>
     <div class='llm-fields' id='llm_hf'>
       <label for='llm_hf_model_id'>Modèle Hugging Face :</label>
-      <input id='llm_hf_model_id' type='text' value='__HF_MODEL_ID__' placeholder='mistralai/Mistral-7B-Instruct-v0.2'>
+      <input id='llm_hf_model_id' type='text' value='__HF_MODEL_ID__' placeholder='HuggingFaceH4/zephyr-7b-beta'>
       <label for='llm_hf_api_token'>Jeton API (optionnel) :</label>
       <input id='llm_hf_api_token' type='password' value=''>
     </div>
@@ -599,6 +600,8 @@ def create_app(analyze_fn: Callable[..., Dict[str, object]] = default_analyze) -
         print(f"TRANSFORMERS_MODEL_ID: {DEFAULT_TRANSFORMERS_MODEL_ID}")
         print(f"LLAMA_MODEL_PATH: {DEFAULT_LLAMA_MODEL_PATH}")
         print(f"HF_MODEL_ID: {DEFAULT_HF_MODEL_ID}")
+        if DEFAULT_HF_MODEL_CANDIDATES:
+            print(f"HF_MODEL_CANDIDATES: {DEFAULT_HF_MODEL_CANDIDATES}")
         print(f"LLM_DEPTH: {DEFAULT_LLM_DEPTH}")
         print(f"LLM_TOP_K: {DEFAULT_LLM_TOP_K}")
         print(f"LLM_PROB_THRESHOLD: {DEFAULT_LLM_PROB_THRESHOLD}")

--- a/README.md
+++ b/README.md
@@ -20,6 +20,47 @@ Oracle is the first chess engine that plays like a human, from amateur to super 
 - **Oracle_web:** Installez `flask` (`pip install flask`) puis lancez `python Oracle_web.py`. Ouvrez le navigateur sur <http://127.0.0.1:8000> pour utiliser l'interface graphique.
   - Réglez ORACLE_WEB_LOG_LEVEL (ex. DEBUG) et ORACLE_WEB_DEBUG=true pour activer un journal détaillé.
 
+## Free Online LLM (Hugging Face Serverless)
+
+Oracle peut fonctionner gratuitement via l'API serverless de Hugging Face en utilisant des modèles d'inférence publics pour la génération de texte. Configurez l'environnement suivant :
+
+1. Créez un compte Hugging Face et générez un token lecture (Settings → Access Tokens). Un token n'est pas obligatoire mais il réduit les limites de taux : <https://huggingface.co/settings/tokens>.
+2. Exportez les variables d'environnement suivantes :
+
+   | Variable | Description | Valeur par défaut |
+   | --- | --- | --- |
+   | `LLM_PROVIDER` | Sélectionne le backend | `hf_serverless` |
+   | `HF_API_TOKEN` | Token optionnel Hugging Face | *(vide)* |
+   | `HF_MODEL_ID` | Modèle primaire text-generation | `HuggingFaceH4/zephyr-7b-beta` |
+   | `HF_MODEL_CANDIDATES` | Liste CSV des candidats (ordre de fallback) | `HuggingFaceH4/zephyr-7b-beta,Qwen/Qwen2.5-7B-Instruct,tiiuae/falcon-7b-instruct` |
+   | `HF_TOP_N_TOKENS` | Nombre de tokens renvoyés par la distribution | `10` |
+   | `HF_TEMPERATURE` | Température (laisser `0` pour un comportement déterministe) | `0` |
+
+   Exemple PowerShell (persistance Windows) :
+
+   ```powershell
+   setx LLM_PROVIDER "hf_serverless"
+   setx HF_API_TOKEN "hf_xxxxxxxxxxxxxxxxx"
+   setx HF_MODEL_ID "HuggingFaceH4/zephyr-7b-beta"
+   setx HF_MODEL_CANDIDATES "HuggingFaceH4/zephyr-7b-beta,Qwen/Qwen2.5-7B-Instruct,tiiuae/falcon-7b-instruct"
+   setx HF_TOP_N_TOKENS "10"
+   setx HF_TEMPERATURE "0"
+   ```
+
+   Exemple `.env` (Unix/macOS) :
+
+   ```bash
+   export LLM_PROVIDER="hf_serverless"
+   export HF_API_TOKEN="hf_xxxxxxxxxxxxxxxxx"
+   export HF_MODEL_ID="HuggingFaceH4/zephyr-7b-beta"
+   export HF_MODEL_CANDIDATES="HuggingFaceH4/zephyr-7b-beta,Qwen/Qwen2.5-7B-Instruct,tiiuae/falcon-7b-instruct"
+   export HF_TOP_N_TOKENS="10"
+   export HF_TEMPERATURE="0"
+   ```
+
+Le provider détecte automatiquement les erreurs « not supported for task text-generation … conversational ». En cas de routage vers un point de terminaison chat-only, il bascule instantanément sur le prochain modèle de `HF_MODEL_CANDIDATES` et relance la requête tout en conservant l'extraction des logprobs (`details` + `top_n_tokens`). Les probabilités retournées pour chaque coup sont normalisées pour sommer à 100 % (±0,1) dans l'API `/api/analyze`.
+
+
 ## Examples
 
 ![Ding vs. Nepo, round 14 after 58...a3](Readme_DingvsNepo_chesscom.png)

--- a/tests/llm/test_hf_serverless_fallback.py
+++ b/tests/llm/test_hf_serverless_fallback.py
@@ -1,0 +1,84 @@
+from typing import Any
+
+import pytest
+
+from oracle.llm.hf_serverless import HuggingFaceServerlessProvider
+
+
+FAKE_RESP = {
+    "generated_text": "e4",
+    "details": {
+        "prefill": [{"id": 1, "text": "..."}],
+        "tokens": [
+            {
+                "id": 99,
+                "text": "e",
+                "logprob": -0.05,
+                "top_tokens": [
+                    {"token": "e", "logprob": -0.05},
+                    {"token": "d", "logprob": -0.25},
+                ],
+            }
+        ],
+    },
+}
+
+
+class StubInferenceClient:
+    def __init__(self, model: str, token: str | None = None) -> None:
+        self.model = model
+        self.token = token
+        self.calls = 0
+
+    def text_generation(self, *args: Any, **kwargs: Any):  # noqa: ANN401
+        self.calls += 1
+        behavior = BEHAVIORS[self.model]
+        if isinstance(behavior, Exception):
+            raise behavior
+        return behavior
+
+
+BEHAVIORS: dict[str, Any] = {}
+
+
+@pytest.fixture(autouse=True)
+def clear_behaviors():
+    BEHAVIORS.clear()
+    yield
+    BEHAVIORS.clear()
+
+
+def test_hf_serverless_switches_model_on_conversational_error(monkeypatch):
+    monkeypatch.setenv(
+        "HF_MODEL_CANDIDATES", "model-a,model-b"
+    )
+
+    created_models: list[str] = []
+
+    def factory(model: str, token: str | None = None):
+        client = StubInferenceClient(model, token)
+        created_models.append(model)
+        return client
+
+    monkeypatch.setattr("oracle.llm.hf_serverless.InferenceClient", factory)
+
+    BEHAVIORS.update(
+        {
+            "model-a": ValueError(
+                "not supported for task text-generation and provider featherless-ai. Supported task: conversational."
+            ),
+            "model-b": FAKE_RESP,
+        }
+    )
+
+    provider = HuggingFaceServerlessProvider(model_id="model-a", api_token="token")
+
+    results = provider.get_top_sequences(
+        "Prompt", ["e4"], depth=1, prob_threshold=0.0, top_k=5
+    )
+
+    assert created_models == ["model-a", "model-b"], "Provider should try fallback model"
+    assert results, "Fallback model should yield token distribution"
+    token, logprob = results[0]
+    assert isinstance(token, str)
+    assert isinstance(logprob, float)

--- a/tests/llm/test_hf_serverless_parsing.py
+++ b/tests/llm/test_hf_serverless_parsing.py
@@ -1,0 +1,43 @@
+from oracle.llm.hf_serverless import HuggingFaceServerlessProvider
+
+
+FAKE_RESP = {
+    "generated_text": "e4",
+    "details": {
+        "prefill": [{"id": 1, "text": "..."}],
+        "tokens": [
+            {
+                "id": 99,
+                "text": "e",
+                "logprob": -0.05,
+                "top_tokens": [
+                    {"token": "e", "logprob": -0.05},
+                    {"token": "d", "logprob": -0.25},
+                ],
+            }
+        ],
+    },
+}
+
+
+class DummyClient:
+    def __init__(self, response):
+        self.response = response
+
+    def text_generation(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        return self.response
+
+
+def test_hf_serverless_parses_top_tokens():
+    provider = HuggingFaceServerlessProvider(
+        model_id="primary", client=DummyClient(FAKE_RESP), top_n_tokens=5
+    )
+
+    results = provider.get_top_sequences(
+        "Prompt", ["e4"], depth=1, prob_threshold=0.0, top_k=5
+    )
+
+    assert results, "Expected at least one token from parsing response"
+    for token, logprob in results:
+        assert isinstance(token, str)
+        assert isinstance(logprob, float)

--- a/tests/llm/test_selector.py
+++ b/tests/llm/test_selector.py
@@ -70,7 +70,7 @@ def test_selector_hf_serverless(monkeypatch):
     monkeypatch.setenv("ORACLE_LLM_PROVIDER", "hf_serverless")
     monkeypatch.setenv("HF_MODEL_ID", "test/model")
     monkeypatch.setenv("HF_TOP_N_TOKENS", "7")
-    monkeypatch.setenv("ORACLE_TEMP", "0")
+    monkeypatch.setenv("HF_TEMPERATURE", "0")
 
     provider = selector.build_sequence_provider()
 


### PR DESCRIPTION
## Summary
- add unit tests covering Hugging Face serverless parsing and fallback rotation
- update the HuggingFaceServerlessProvider to manage candidate lists, auto-switch on conversational-only errors, and surface the active model
- refresh web defaults and documentation for the Zephyr-based serverless configuration with optional fallbacks

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d41c89b9d88327b36e44c708e0b299