### PR TITLE
Update default Hugging Face serverless models

### DIFF
--- a/Oracle_web.py
+++ b/Oracle_web.py
@@ -45,7 +45,7 @@ try:
     _HF_DEFAULTS = load_hf_settings_from_env()
 except RuntimeError:
     _HF_DEFAULTS = {
-        "model_id": "HuggingFaceH4/zephyr-7b-beta",
+        "model_id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
         "api_token": None,
         "top_n_tokens": 10,
         "temperature": 0.0,
@@ -142,7 +142,7 @@ INDEX_HTML_TEMPLATE = """<!doctype html>
     </div>
     <div class='llm-fields' id='llm_hf'>
       <label for='llm_hf_model_id'>Modèle Hugging Face :</label>
-      <input id='llm_hf_model_id' type='text' value='__HF_MODEL_ID__' placeholder='HuggingFaceH4/zephyr-7b-beta'>
+      <input id='llm_hf_model_id' type='text' value='__HF_MODEL_ID__' placeholder='meta-llama/Meta-Llama-3.1-8B-Instruct'>
       <label for='llm_hf_api_token'>Jeton API (optionnel) :</label>
       <input id='llm_hf_api_token' type='password' value=''>
     </div>

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Oracle peut fonctionner gratuitement via l'API serverless de Hugging Face en uti
    | --- | --- | --- |
    | `LLM_PROVIDER` | Sélectionne le backend | `hf_serverless` |
    | `HF_API_TOKEN` | Token optionnel Hugging Face | *(vide)* |
-   | `HF_MODEL_ID` | Modèle primaire text-generation | `HuggingFaceH4/zephyr-7b-beta` |
-   | `HF_MODEL_CANDIDATES` | Liste CSV des candidats (ordre de fallback) | `HuggingFaceH4/zephyr-7b-beta,Qwen/Qwen2.5-7B-Instruct,tiiuae/falcon-7b-instruct` |
+   | `HF_MODEL_ID` | Modèle primaire text-generation | `meta-llama/Meta-Llama-3.1-8B-Instruct` |
+   | `HF_MODEL_CANDIDATES` | Liste CSV des candidats (ordre de fallback) | `meta-llama/Meta-Llama-3.1-8B-Instruct,mistralai/Mistral-7B-Instruct-v0.3,mistralai/Mistral-Nemo-Instruct-2407,google/gemma-2-9b-it,Qwen/Qwen2.5-7B-Instruct` |
    | `HF_TOP_N_TOKENS` | Nombre de tokens renvoyés par la distribution | `10` |
    | `HF_TEMPERATURE` | Température (laisser `0` pour un comportement déterministe) | `0` |
 
@@ -41,8 +41,8 @@ Oracle peut fonctionner gratuitement via l'API serverless de Hugging Face en uti
    ```powershell
    setx LLM_PROVIDER "hf_serverless"
    setx HF_API_TOKEN "hf_xxxxxxxxxxxxxxxxx"
-   setx HF_MODEL_ID "HuggingFaceH4/zephyr-7b-beta"
-   setx HF_MODEL_CANDIDATES "HuggingFaceH4/zephyr-7b-beta,Qwen/Qwen2.5-7B-Instruct,tiiuae/falcon-7b-instruct"
+   setx HF_MODEL_ID "meta-llama/Meta-Llama-3.1-8B-Instruct"
+   setx HF_MODEL_CANDIDATES "meta-llama/Meta-Llama-3.1-8B-Instruct,mistralai/Mistral-7B-Instruct-v0.3,mistralai/Mistral-Nemo-Instruct-2407,google/gemma-2-9b-it,Qwen/Qwen2.5-7B-Instruct"
    setx HF_TOP_N_TOKENS "10"
    setx HF_TEMPERATURE "0"
    ```
@@ -52,8 +52,8 @@ Oracle peut fonctionner gratuitement via l'API serverless de Hugging Face en uti
    ```bash
    export LLM_PROVIDER="hf_serverless"
    export HF_API_TOKEN="hf_xxxxxxxxxxxxxxxxx"
-   export HF_MODEL_ID="HuggingFaceH4/zephyr-7b-beta"
-   export HF_MODEL_CANDIDATES="HuggingFaceH4/zephyr-7b-beta,Qwen/Qwen2.5-7B-Instruct,tiiuae/falcon-7b-instruct"
+   export HF_MODEL_ID="meta-llama/Meta-Llama-3.1-8B-Instruct"
+   export HF_MODEL_CANDIDATES="meta-llama/Meta-Llama-3.1-8B-Instruct,mistralai/Mistral-7B-Instruct-v0.3,mistralai/Mistral-Nemo-Instruct-2407,google/gemma-2-9b-it,Qwen/Qwen2.5-7B-Instruct"
    export HF_TOP_N_TOKENS="10"
    export HF_TEMPERATURE="0"
    ```

--- a/tests/test_hf_serverless_provider.py
+++ b/tests/test_hf_serverless_provider.py
@@ -1,0 +1,68 @@
+import types
+
+import pytest
+
+from oracle.llm.hf_serverless import (
+    SAFE_SERVERLESS_MODELS,
+    HuggingFaceServerlessProvider,
+    _extract_status_code,
+)
+
+
+class _Dummy404Error(Exception):
+    status_code = 404
+
+
+class _Always404Client:
+    def __init__(self):
+        self.calls = 0
+
+    def text_generation(self, *args, **kwargs):
+        self.calls += 1
+        raise _Dummy404Error("missing model")
+
+
+def _build_provider_for_test(models):
+    provider = object.__new__(HuggingFaceServerlessProvider)
+    provider.models = list(models)
+    provider._model_idx = 0
+    provider._client_cache = {model: _Always404Client() for model in provider.models}
+    provider._client_factory = None
+    provider.client = provider._client_cache[provider.models[0]]
+    provider.max_retries = 1
+    provider.retry_base_delay = 0.0
+    provider.rate_limit_delay = 0.0
+    provider._sleep = lambda _: None
+    provider.do_sample = False
+    provider.temperature = 0.0
+    return provider
+
+
+def test_safe_serverless_models_default_list():
+    provider = object.__new__(HuggingFaceServerlessProvider)
+    candidates = provider._build_candidate_list("")
+    assert candidates[0] == SAFE_SERVERLESS_MODELS[0]
+    assert candidates[: len(SAFE_SERVERLESS_MODELS)] == SAFE_SERVERLESS_MODELS
+
+
+def test_call_with_retries_reraises_with_hint():
+    provider = _build_provider_for_test(["missing-one", "missing-two"])
+    with pytest.raises(RuntimeError) as excinfo:
+        provider._call_with_retries("prompt", 3)
+    message = str(excinfo.value)
+    assert "returned 404" in message
+    assert "missing-one" in message and "missing-two" in message
+
+
+@pytest.mark.parametrize(
+    "error, expected",
+    [
+        (_Dummy404Error(), 404),
+        (types.SimpleNamespace(status_code=503), 503),
+        (types.SimpleNamespace(response=types.SimpleNamespace(status_code=401)), 401),
+        (types.SimpleNamespace(request=types.SimpleNamespace(status_code=500)), 500),
+        (ValueError("no code"), None),
+    ],
+)
+def test_extract_status_code_variants(error, expected):
+    assert _extract_status_code(error) == expected


### PR DESCRIPTION
## Summary
- refresh the default Hugging Face serverless candidate list and provide clearer guidance when every model returns 404
- update the web UI placeholder and documentation to reference the new recommended inference endpoints
- add tests covering the refreshed candidate list and the improved 404 handling logic

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d489a3abb8832797200de45bd9ece3