### PR TITLE
Handle invalid numeric config environment variables

### DIFF
--- a/oracle/config.py
+++ b/oracle/config.py
@@ -24,16 +24,51 @@ class Settings:
     hash_size: int = 512
 
 
+def _coerce_float_env(var_name: str, default: float) -> float:
+    """Return a float environment variable or a default on failure."""
+
+    raw_value = os.getenv(var_name)
+    if raw_value is None:
+        return default
+
+    stripped = raw_value.strip()
+    if stripped == "":
+        return default
+
+    try:
+        return float(stripped)
+    except ValueError:
+        return default
+
+
+def _coerce_int_env(var_name: str, default: int) -> int:
+    """Return an int environment variable or a default on failure."""
+
+    raw_value = os.getenv(var_name)
+    if raw_value is None:
+        return default
+
+    stripped = raw_value.strip()
+    if stripped == "":
+        return default
+
+    try:
+        return int(stripped)
+    except ValueError:
+        return default
+
+
 def load_settings() -> Settings:
     """Load configuration from environment variables."""
+
     return Settings(
         openai_api_key=os.getenv("OPENAI_API_KEY", ""),
         stockfish_path=os.getenv("STOCKFISH_PATH", ""),
         model_name=os.getenv("OPENAI_MODEL", DEFAULT_MODEL),
-        time_limit=float(os.getenv("STOCKFISH_TIME_LIMIT", 1.3)),
-        depth=int(os.getenv("STOCKFISH_DEPTH", 20)),
-        threads=int(os.getenv("STOCKFISH_THREADS", 8)),
-        hash_size=int(os.getenv("STOCKFISH_HASH", 512)),
+        time_limit=_coerce_float_env("STOCKFISH_TIME_LIMIT", 1.3),
+        depth=_coerce_int_env("STOCKFISH_DEPTH", 20),
+        threads=_coerce_int_env("STOCKFISH_THREADS", 8),
+        hash_size=_coerce_int_env("STOCKFISH_HASH", 512),
     )
 
 
@@ -41,4 +76,9 @@ def resolve_value(explicit: Optional[str], fallback: str) -> str:
     return explicit if explicit not in (None, "") else fallback
 
 
-__all__ = ["Settings", "load_settings", "resolve_value", "DEFAULT_MODEL"]
+__all__ = [
+    "Settings",
+    "load_settings",
+    "resolve_value",
+    "DEFAULT_MODEL",
+]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,37 @@
+"""Tests for configuration loading helpers."""
+
+from __future__ import annotations
+
+from oracle import config
+
+
+def test_load_settings_recovers_from_invalid_numbers(monkeypatch):
+    """Invalid numeric env vars should fall back to defaults."""
+
+    monkeypatch.setenv("STOCKFISH_TIME_LIMIT", "not-a-number")
+    monkeypatch.setenv("STOCKFISH_DEPTH", "twenty")
+    monkeypatch.setenv("STOCKFISH_THREADS", "  ")
+    monkeypatch.setenv("STOCKFISH_HASH", "n/a")
+
+    settings = config.load_settings()
+
+    assert settings.time_limit == 1.3
+    assert settings.depth == 20
+    assert settings.threads == 8
+    assert settings.hash_size == 512
+
+
+def test_load_settings_accepts_zero_values(monkeypatch):
+    """Zero values are valid inputs and should be preserved."""
+
+    monkeypatch.setenv("STOCKFISH_TIME_LIMIT", "0")
+    monkeypatch.setenv("STOCKFISH_DEPTH", "0")
+    monkeypatch.setenv("STOCKFISH_THREADS", "0")
+    monkeypatch.setenv("STOCKFISH_HASH", "0")
+
+    settings = config.load_settings()
+
+    assert settings.time_limit == 0.0
+    assert settings.depth == 0
+    assert settings.threads == 0
+    assert settings.hash_size == 0


### PR DESCRIPTION
## Summary
- ensure numeric Stockfish configuration values gracefully fall back to defaults when the environment contains invalid strings
- keep support for zero-valued overrides and cover the new behaviour with unit tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1cb9c3d788327be16ae519f2163d2